### PR TITLE
fix: add chain-specific regex validation for wallet addresses

### DIFF
--- a/bot/src/bot.ts
+++ b/bot/src/bot.ts
@@ -12,6 +12,88 @@ import path from 'path';
 import { execSync } from 'child_process';
 import express from 'express';
 
+// --- ADDRESS VALIDATION ---
+// Regex patterns for validating wallet addresses by chain type
+const ADDRESS_PATTERNS: Record<string, RegExp> = {
+  // EVM-compatible chains (Ethereum, BSC, Polygon, Arbitrum, Base, Avalanche, etc.)
+  ethereum: /^0x[a-fA-F0-9]{40}$/,
+  bsc: /^0x[a-fA-F0-9]{40}$/,
+  polygon: /^0x[a-fA-F0-9]{40}$/,
+  arbitrum: /^0x[a-fA-F0-9]{40}$/,
+  base: /^0x[a-fA-F0-9]{40}$/,
+  avalanche: /^0x[a-fA-F0-9]{40}$/,
+  optimism: /^0x[a-fA-F0-9]{40}$/,
+  fantom: /^0x[a-fA-F0-9]{40}$/,
+  // Bitcoin (Legacy, SegWit, Native SegWit, Taproot)
+  bitcoin: /^(1[a-km-zA-HJ-NP-Z1-9]{25,34}|3[a-km-zA-HJ-NP-Z1-9]{25,34}|bc1[a-zA-HJ-NP-Z0-9]{39,59}|bc1p[a-zA-HJ-NP-Z0-9]{58})$/,
+  // Litecoin (Legacy, SegWit)
+  litecoin: /^([LM3][a-km-zA-HJ-NP-Z1-9]{26,33}|ltc1[a-zA-HJ-NP-Z0-9]{39,59})$/,
+  // Solana
+  solana: /^[1-9A-HJ-NP-Za-km-z]{32,44}$/,
+  // Tron
+  tron: /^T[a-zA-HJ-NP-Z0-9]{33}$/,
+  // Ripple (XRP)
+  ripple: /^r[0-9a-zA-Z]{24,34}$/,
+  xrp: /^r[0-9a-zA-Z]{24,34}$/,
+  // Dogecoin
+  dogecoin: /^D[5-9A-HJ-NP-U][1-9A-HJ-NP-Za-km-z]{32}$/,
+  // Cosmos-based chains
+  cosmos: /^cosmos[a-z0-9]{38,45}$/,
+  // Polkadot
+  polkadot: /^1[a-zA-Z0-9]{47}$/,
+  // Cardano
+  cardano: /^addr1[a-zA-Z0-9]{53,}$/,
+  // Monero
+  monero: /^4[0-9AB][1-9A-HJ-NP-Za-km-z]{93}$/,
+  // Zcash (transparent)
+  zcash: /^t1[a-zA-Z0-9]{33}$/,
+};
+
+// Default EVM pattern for unknown chains
+const DEFAULT_EVM_PATTERN = /^0x[a-fA-F0-9]{40}$/;
+
+/**
+ * Validates a wallet address against the expected format for a given chain.
+ * @param address - The wallet address to validate
+ * @param chain - The blockchain network (e.g., 'ethereum', 'bitcoin', 'solana')
+ * @returns boolean indicating if the address is valid for the specified chain
+ */
+function isValidAddress(address: string, chain?: string): boolean {
+  if (!address || typeof address !== 'string') {
+    return false;
+  }
+
+  const trimmedAddress = address.trim();
+  
+  // If no chain specified, check if it matches any known pattern
+  if (!chain) {
+    // Check EVM first (most common)
+    if (DEFAULT_EVM_PATTERN.test(trimmedAddress)) {
+      return true;
+    }
+    // Check other common patterns
+    for (const pattern of Object.values(ADDRESS_PATTERNS)) {
+      if (pattern.test(trimmedAddress)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Normalize chain name
+  const normalizedChain = chain.toLowerCase().replace(/[^a-z]/g, '');
+  
+  // Get the pattern for the specified chain
+  const pattern = ADDRESS_PATTERNS[normalizedChain];
+  
+  if (pattern) {
+    return pattern.test(trimmedAddress);
+  }
+  
+  // For unknown chains, assume EVM-compatible
+  return DEFAULT_EVM_PATTERN.test(trimmedAddress);
+}
+
 dotenv.config();
 const MINI_APP_URL = process.env.MINI_APP_URL!;
 const ADMIN_CHAT_ID = process.env.ADMIN_CHAT_ID;
@@ -207,8 +289,11 @@ async function handleTextMessage(ctx: any, text: string, inputType: 'text' | 'vo
   // 1. Check for pending address input
   if (state?.parsedCommand && (state.parsedCommand.intent === 'swap' || state.parsedCommand.intent === 'checkout') && !state.parsedCommand.settleAddress) {
       const potentialAddress = text.trim();
-      // Basic address validation (can be improved)
-      if (potentialAddress.length > 25) { // Arbitrary length check for now
+      // Get the target chain for validation (use toChain for swaps, settleNetwork for checkouts)
+      const targetChain = state.parsedCommand.toChain || state.parsedCommand.settleNetwork;
+      
+      // Validate address format based on the target chain
+      if (isValidAddress(potentialAddress, targetChain)) {
           const updatedCommand = { ...state.parsedCommand, settleAddress: potentialAddress };
           await db.setConversationState(userId, { parsedCommand: updatedCommand });
           
@@ -221,7 +306,8 @@ async function handleTextMessage(ctx: any, text: string, inputType: 'text' | 'vo
               Markup.button.callback('❌ No', 'cancel_swap')
           ]));
       } else {
-          return ctx.reply("That doesn't look like a valid address. Please try again or /clear to cancel.");
+          const chainHint = targetChain ? ` for ${targetChain}` : '';
+          return ctx.reply(`That doesn't look like a valid wallet address${chainHint}. Please provide a valid address or /clear to cancel.`);
       }
   }
 


### PR DESCRIPTION
## 🐛 Issue
Fixes the wallet address validation bug in `bot/src/bot.ts`

##  Problem (Before)
The validation only checked `potentialAddress.length > 25`, allowing invalid text to pass:

// OLD CODE - Line 211
if (potentialAddress.length > 25) // Arbitrary length check

 Solution (After)
Added [isValidAddress()]function with chain-specific regex patterns for:

EVM chains: Ethereum, BSC, Polygon, Arbitrum, Base, Avalanche, Optimism, Fantom
Bitcoin: Legacy, SegWit, Native SegWit, Taproot
Others: Solana, Tron, XRP, Litecoin, Dogecoin, Cosmos, Polkadot, Cardano, Monero, Zcash

 Testing Screenshots
Test 1: Invalid text REJECTED ✅
When user sends "I want to swap this immediately please" as address:

![WhatsApp Image 2026-01-26 at 1 43 07 PM (1)](https://github.com/user-attachments/assets/f2c9ca61-8c27-47f6-bbe0-192d11cfaba7)


![WhatsApp Image 2026-01-26 at 1 43 06 PM](https://github.com/user-attachments/assets/9a4ccf24-3e3d-4e9c-9b68-6e90788d2e09)


Bot responds: "That doesn't look like a valid wallet address for polygon. Please provide a valid address or /clear to cancel."

Test 2: Valid address ACCEPTED ✅
When user sends 0x742d35Cc6634C0532925a3b844Bc9e7595f1dE3b

![WhatsApp Image 2026-01-26 at 1 43 07 PM](https://github.com/user-attachments/assets/5056ed29-1e4a-4343-b71f-8f09917a6a12)


Bot responds: "Address received: 0x742d35Cc6634C0532925a3b844Bc9e7595f1dE3b" and shows confirmation buttons.

<img width="1246" height="943" alt="Screenshot 2026-01-26 132547" src="https://github.com/user-attachments/assets/23f9460a-c5a3-4aef-90c8-641be2bac2b8" />


📁 Files Changed
[bot.ts] Added address validation regex patterns and [isValidAddress()] function
✔️ Checklist
 Code compiles without TypeScript errors
 Tested locally with Telegram bot

