### PR TITLE
Misparsing of Complex or Ambiguous User Commands

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -7,6 +7,7 @@
     "build": "tsc",
     "start": "node dist/bot.js",
     "dev": "ts-node-dev --respawn --transpile-only src/bot.ts",
+    "test": "jest",
     "db:gen": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio",
@@ -30,9 +31,18 @@
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
     "@types/express": "^5.0.3",
+    "@types/jest": "^29.5.12",
     "@types/node": "^24.7.2",
     "drizzle-kit": "^0.31.7",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.4",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.9.3"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "roots": ["<rootDir>/src"],
+    "testMatch": ["**/__tests__/**/*.test.ts", "**/?(*.)+(spec|test).ts"]
   }
 }

--- a/bot/src/bot.ts
+++ b/bot/src/bot.ts
@@ -233,7 +233,11 @@ async function handleTextMessage(ctx: any, text: string, inputType: 'text' | 'vo
   
   if (!parsed.success && parsed.intent !== 'yield_scout') {
       await logAnalytics(ctx, 'ValidationError', { input: text, error: parsed.validationErrors.join(", ") });
-      return ctx.reply(`⚠️ ${parsed.validationErrors.join(", ") || "I didn't understand."}`);
+      let errorMessage = `⚠️ ${parsed.validationErrors.join(", ") || "I didn't understand."}`;
+      if (parsed.confidence < 50) {
+        errorMessage += "\n\n💡 *Suggestion:* Try rephrasing your command. For example:\n- Instead of 'swap to BTC or USDC', say 'swap to BTC'\n- For splits: 'split 1 ETH into 50% BTC and 50% USDC'";
+      }
+      return ctx.replyWithMarkdown(errorMessage);
   }
 
   if (parsed.intent === 'yield_scout') {

--- a/bot/src/tests/parse-command.test.ts
+++ b/bot/src/tests/parse-command.test.ts
@@ -1,0 +1,168 @@
+import { parseUserCommand } from '../services/groq-client';
+
+// Mock the groq-sdk module
+jest.mock('groq-sdk', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      chat: {
+        completions: {
+          create: jest.fn().mockResolvedValue({
+            choices: [{
+              message: {
+                content: JSON.stringify({
+                  success: true,
+                  intent: 'swap',
+                  fromAsset: 'ETH',
+                  fromChain: 'ethereum',
+                  toAsset: 'BTC',
+                  toChain: 'bitcoin',
+                  amount: 1,
+                  confidence: 95,
+                  validationErrors: [],
+                  parsedMessage: 'Swap 1 ETH to BTC'
+                })
+              }
+            }]
+          })
+        }
+      }
+    }))
+  };
+});
+
+describe('parseUserCommand', () => {
+  it('should parse a clear swap command', async () => {
+    const result = await parseUserCommand('swap 1 ETH to BTC');
+    expect(result.success).toBe(true);
+    expect(result.intent).toBe('swap');
+    expect(result.fromAsset).toBe('ETH');
+    expect(result.toAsset).toBe('BTC');
+  });
+
+  it('should handle ambiguous command with low confidence', async () => {
+    // Mock ambiguous response
+    const mockGroq = require('groq-sdk');
+    mockGroq.mockImplementation(() => ({
+      chat: {
+        completions: {
+          create: jest.fn().mockResolvedValue({
+            choices: [{
+              message: {
+                content: JSON.stringify({
+                  success: false,
+                  intent: 'swap',
+                  fromAsset: 'ETH',
+                  toAsset: null,
+                  confidence: 20,
+                  validationErrors: ['Command is ambiguous. Please specify clearly.'],
+                  parsedMessage: ''
+                })
+              }
+            }]
+          })
+        }
+      }
+    }));
+
+    const result = await parseUserCommand('swap 1 ETH to BTC or USDC');
+    expect(result.success).toBe(false);
+    expect(result.confidence).toBeLessThan(50);
+    expect(result.validationErrors).toContain('Low confidence in parsing. Please rephrase your command for clarity.');
+  });
+
+  it('should parse portfolio allocation correctly', async () => {
+    const mockGroq = require('groq-sdk');
+    mockGroq.mockImplementation(() => ({
+      chat: {
+        completions: {
+          create: jest.fn().mockResolvedValue({
+            choices: [{
+              message: {
+                content: JSON.stringify({
+                  success: true,
+                  intent: 'portfolio',
+                  fromAsset: 'ETH',
+                  fromChain: 'base',
+                  amount: 1,
+                  portfolio: [
+                    { toAsset: 'USDC', toChain: 'arbitrum', percentage: 50 },
+                    { toAsset: 'SOL', toChain: 'solana', percentage: 50 }
+                  ],
+                  confidence: 95,
+                  validationErrors: [],
+                  parsedMessage: 'Split 1 ETH into 50% USDC and 50% SOL'
+                })
+              }
+            }]
+          })
+        }
+      }
+    }));
+
+    const result = await parseUserCommand('split 1 ETH into 50% USDC and 50% SOL');
+    expect(result.success).toBe(true);
+    expect(result.intent).toBe('portfolio');
+    expect(result.portfolio).toHaveLength(2);
+  });
+
+  it('should validate portfolio percentages', async () => {
+    const mockGroq = require('groq-sdk');
+    mockGroq.mockImplementation(() => ({
+      chat: {
+        completions: {
+          create: jest.fn().mockResolvedValue({
+            choices: [{
+              message: {
+                content: JSON.stringify({
+                  success: true,
+                  intent: 'portfolio',
+                  fromAsset: 'ETH',
+                  amount: 1,
+                  portfolio: [
+                    { toAsset: 'BTC', toChain: 'bitcoin', percentage: 60 },
+                    { toAsset: 'USDC', toChain: 'ethereum', percentage: 50 }
+                  ],
+                  confidence: 80,
+                  validationErrors: [],
+                  parsedMessage: 'Invalid portfolio'
+                })
+              }
+            }]
+          })
+        }
+      }
+    }));
+
+    const result = await parseUserCommand('split 1 ETH into 60% BTC and 50% USDC');
+    expect(result.success).toBe(false);
+    expect(result.validationErrors).toContain('Total allocation is 110%, but should be 100%');
+  });
+
+  it('should handle yield scout intent', async () => {
+    const mockGroq = require('groq-sdk');
+    mockGroq.mockImplementation(() => ({
+      chat: {
+        completions: {
+          create: jest.fn().mockResolvedValue({
+            choices: [{
+              message: {
+                content: JSON.stringify({
+                  success: true,
+                  intent: 'yield_scout',
+                  confidence: 100,
+                  validationErrors: [],
+                  parsedMessage: 'Looking for yield opportunities'
+                })
+              }
+            }]
+          })
+        }
+      }
+    }));
+
+    const result = await parseUserCommand('where can I get good yield?');
+    expect(result.success).toBe(true);
+    expect(result.intent).toBe('yield_scout');
+  });
+});


### PR DESCRIPTION
## What Was Accomplished:
Enhanced AI Prompt (bot/src/services/groq-client.ts):

- 
- Added ambiguity handling with confidence scoring (0-100)
- Instructions for detecting unclear commands like "swap to BTC or USDC"
- Better support for conditional swaps and portfolio allocations
- Added examples for ambiguous scenarios

Improved Validation Logic:

- Low confidence detection (<50%) triggers automatic error messages
- Enhanced portfolio percentage validation (must sum to 100%)
- Better error categorization and user guidance

Enhanced Error Handling (bot/src/bot.ts):

- Clearer feedback for parsing failures
- Actionable suggestions for rephrasing ambiguous commands
- Inline examples (e.g., "Instead of 'swap to BTC or USDC', say 'swap to BTC'")

Unit Test Suite (bot/src/tests/parse-command.test.ts):

- Tests for clear swap commands
- Tests for ambiguous command detection
- Tests for portfolio allocation validation
- Tests for yield scout functionality
- Jest configuration added to package.json

solves #27