### PR TITLE
Automate Deposits on Yield

### DIFF
--- a/bot/src/services/groq-client.ts
+++ b/bot/src/services/groq-client.ts
@@ -9,7 +9,7 @@ const groq = new Groq({ apiKey: process.env.GROQ_API_KEY });
 // Enhanced Interface to support Portfolio and Yield
 export interface ParsedCommand {
   success: boolean;
-  intent: "swap" | "checkout" | "portfolio" | "yield_scout" | "unknown";
+  intent: "swap" | "checkout" | "portfolio" | "yield_scout" | "yield_deposit" | "unknown";
   
   // Single Swap Fields
   fromAsset: string | null;
@@ -48,6 +48,7 @@ MODES:
 2. "portfolio": 1 Input -> Multiple Outputs (Split allocation).
 3. "checkout": Payment link creation.
 4. "yield_scout": User asking for high APY/Yield info.
+5. "yield_deposit": Deposit assets into yield platforms, possibly bridging if needed.
 
 STANDARDIZED CHAINS: ethereum, bitcoin, polygon, arbitrum, avalanche, optimism, bsc, base, solana.
 
@@ -60,7 +61,7 @@ AMBIGUITY HANDLING:
 RESPONSE FORMAT:
 {
   "success": boolean,
-  "intent": "swap" | "portfolio" | "checkout" | "yield_scout",
+  "intent": "swap" | "portfolio" | "checkout" | "yield_scout" | "yield_deposit",
   "fromAsset": string | null,
   "fromChain": string | null,
   "amount": number | null,
@@ -100,6 +101,9 @@ EXAMPLES:
 
 4. "If ETH > $3000, swap to BTC, else to USDC" (conditional)
    -> intent: "portfolio", fromAsset: "ETH", portfolio: [{toAsset: "BTC", toChain: "bitcoin", percentage: 100}], confidence: 70, parsedMessage: "Conditional swap: If ETH > $3000, swap to BTC", requiresConfirmation: true
+
+5. "Deposit 1 ETH to yield"
+   -> intent: "yield_deposit", fromAsset: "ETH", amount: 1, confidence: 95
 `;
 
 export async function parseUserCommand(

--- a/bot/src/tests/parse-command.test.ts
+++ b/bot/src/tests/parse-command.test.ts
@@ -165,4 +165,35 @@ describe('parseUserCommand', () => {
     expect(result.success).toBe(true);
     expect(result.intent).toBe('yield_scout');
   });
+
+  it('should handle yield deposit intent', async () => {
+    const mockGroq = require('groq-sdk');
+    mockGroq.mockImplementation(() => ({
+      chat: {
+        completions: {
+          create: jest.fn().mockResolvedValue({
+            choices: [{
+              message: {
+                content: JSON.stringify({
+                  success: true,
+                  intent: 'yield_deposit',
+                  fromAsset: 'ETH',
+                  amount: 1,
+                  confidence: 95,
+                  validationErrors: [],
+                  parsedMessage: 'Depositing 1 ETH to yield'
+                })
+              }
+            }]
+          })
+        }
+      }
+    }));
+
+    const result = await parseUserCommand('deposit 1 ETH to yield');
+    expect(result.success).toBe(true);
+    expect(result.intent).toBe('yield_deposit');
+    expect(result.fromAsset).toBe('ETH');
+    expect(result.amount).toBe(1);
+  });
 });


### PR DESCRIPTION
## Completed Features
**Made Yield Options More Obvious**

- Added a /yield command to the bot that displays top stablecoin yield opportunities
- Updated the welcome message to include the /yield command in the command list

**Added Yield Deposit Intent**

- Extended the ParsedCommand interface to support yield_deposit intent
- Updated the AI system prompt to recognize deposit commands like "deposit 1 ETH to yield"
- Added validation for yield deposit commands

**Automated Deposit Logic**

- Implemented logic in bot.ts to handle yield_deposit intent
- Automatically checks if the user is on the correct chain for the yield pool
- If on a different chain, initiates a bridge via SideShift to move assets to the yield chain
- If already on the correct chain, proceeds with swapping to the yield asset (simplified automation)

**Enhanced Yield Client**

- Added YieldPool interface and getTopYieldPools() function to retrieve structured yield data
- Maintained backward compatibility with existing getTopStablecoinYields() function

**Added Tests**

Created a test case for yield_deposit intent parsing in parse-command.test.ts

**Voice Automation Support**

- The implementation works with both text and voice inputs through the existing transcription system

solves #15