### PR TITLE
feat: persistent transaction monitoring (#60)

### DIFF
--- a/bot/drizzle/0003_persistent_transaction_monitoring.sql
+++ b/bot/drizzle/0003_persistent_transaction_monitoring.sql
@@ -1,0 +1,10 @@
+-- Create watched_orders table for persistent transaction monitoring
+CREATE TABLE IF NOT EXISTS "watched_orders" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"telegram_id" bigint NOT NULL,
+	"sideshift_order_id" text NOT NULL,
+	"last_status" text DEFAULT 'pending' NOT NULL,
+	"last_checked" timestamp DEFAULT now(),
+	"created_at" timestamp DEFAULT now(),
+	CONSTRAINT "watched_orders_sideshift_order_id_unique" UNIQUE("sideshift_order_id")
+);

--- a/bot/src/bot.ts
+++ b/bot/src/bot.ts
@@ -14,10 +14,14 @@ import express from 'express';
 import { chainIdMap } from './config/chains';
 import { handleError } from './services/logger';
 import { tokenResolver } from './services/token-resolver';
+import { OrderMonitor } from './services/order-monitor';
 
 dotenv.config();
 const MINI_APP_URL = process.env.MINI_APP_URL!;
 const bot = new Telegraf(process.env.BOT_TOKEN!);
+
+// Initialize order monitor
+const orderMonitor = new OrderMonitor(bot);
 
 // --- ADDRESS VALIDATION PATTERNS ---
 const ADDRESS_PATTERNS: Record<string, RegExp> = {
@@ -143,6 +147,9 @@ bot.start((ctx) => {
         "/history - See past orders\n" +
         "/checkouts - See payment links\n" +
         "/status [id] - Check order status\n" +
+        "/watch [id] - Watch order for completion\n" +
+        "/unwatch [id] - Stop watching order\n" +
+        "/watching - List watched orders\n" +
         "/clear - Reset conversation\n\n" +
         "💡 *Tip:* Check out our web interface for a graphical experience!",
         {
@@ -199,6 +206,92 @@ bot.command('status', async (ctx) => {
     } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred.';
         ctx.reply(`Sorry, couldn't get status. Error: ${errorMessage}`);
+    }
+});
+
+bot.command('watch', async (ctx) => {
+    const userId = ctx.from.id;
+    const args = ctx.message.text.split(' ');
+    let orderIdToWatch: string | null = args[1];
+
+    try {
+        if (!orderIdToWatch) {
+            const lastOrder = await db.getLatestUserOrder(userId);
+            if (!lastOrder) return ctx.reply("You have no order history to watch. Send a swap first.");
+            orderIdToWatch = lastOrder.sideshiftOrderId;
+        }
+
+        // Check if order exists and get its current status
+        await ctx.reply(`⏳ Setting up watch for order \`${orderIdToWatch}\`...`, { parse_mode: 'Markdown' });
+        const status = await getOrderStatus(orderIdToWatch);
+        
+        // Check if already completed
+        if (status.status.toLowerCase() === 'settled' || status.status.toLowerCase() === 'refunded') {
+            return ctx.reply(`⚠️ Order \`${orderIdToWatch}\` is already ${status.status}. No need to watch.`, { parse_mode: 'Markdown' });
+        }
+
+        // Add to watch list
+        await db.addWatchedOrder(userId, orderIdToWatch, status.status);
+        
+        let message = `✅ *Now watching order:* \`${orderIdToWatch}\`\n\n`;
+        message += `*Current Status:* \`${status.status.toUpperCase()}\`\n`;
+        message += `*Send:* ${status.depositAmount || '?'} ${status.depositCoin} (${status.depositNetwork})\n`;
+        message += `*Receive:* ${status.settleAmount || '?'} ${status.settleCoin} (${status.settleNetwork})\n\n`;
+        message += `🔔 I'll notify you when the status changes or when it's completed!`;
+
+        ctx.replyWithMarkdown(message);
+    } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred.';
+        ctx.reply(`Sorry, couldn't watch order. Error: ${errorMessage}`);
+    }
+});
+
+bot.command('unwatch', async (ctx) => {
+    const userId = ctx.from.id;
+    const args = ctx.message.text.split(' ');
+    let orderIdToUnwatch: string | null = args[1];
+
+    try {
+        if (!orderIdToUnwatch) {
+            const watchedOrders = await db.getUserWatchedOrders(userId);
+            if (watchedOrders.length === 0) {
+                return ctx.reply("You have no watched orders.");
+            }
+            orderIdToUnwatch = watchedOrders[0].sideshiftOrderId;
+        }
+
+        await db.removeWatchedOrder(orderIdToUnwatch);
+        ctx.reply(`✅ Stopped watching order \`${orderIdToUnwatch}\``, { parse_mode: 'Markdown' });
+    } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred.';
+        ctx.reply(`Sorry, couldn't unwatch order. Error: ${errorMessage}`);
+    }
+});
+
+bot.command('watching', async (ctx) => {
+    const userId = ctx.from.id;
+    
+    try {
+        const watchedOrders = await db.getUserWatchedOrders(userId);
+        
+        if (watchedOrders.length === 0) {
+            return ctx.reply("You are not watching any orders.\n\nUse /watch [order_id] to start monitoring an order.");
+        }
+
+        let message = `🔍 *Your Watched Orders:*\n\n`;
+        
+        for (const watched of watchedOrders) {
+            message += `*Order:* \`${watched.sideshiftOrderId}\`\n`;
+            message += `  *Status:* \`${watched.lastStatus.toUpperCase()}\`\n`;
+            message += `  *Last Checked:* ${new Date(watched.lastChecked as Date).toLocaleString()}\n\n`;
+        }
+        
+        message += `💡 Use /unwatch [order_id] to stop watching an order.`;
+        
+        ctx.replyWithMarkdown(message);
+    } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred.';
+        ctx.reply(`Sorry, couldn't fetch watched orders. Error: ${errorMessage}`);
     }
 });
 
@@ -483,6 +576,9 @@ bot.action('place_order', async (ctx) => {
         if (!order.id) throw new Error("Failed to create order");
 
         db.createOrderEntry(userId, state.parsedCommand, order, state.settleAmount, state.quoteId);
+        
+        // Automatically add order to watch list
+        await db.addWatchedOrder(userId, order.id, 'pending');
 
         const { amount, fromChain, fromAsset } = state.parsedCommand;
         const rawDepositAddress = typeof order.depositAddress === 'string' ? order.depositAddress : order.depositAddress.address;
@@ -515,7 +611,7 @@ bot.action('place_order', async (ctx) => {
             token: assetKey, amount: amount!.toString()
         });
 
-        ctx.editMessageText(`✅ *Order Created!*\nTo complete the swap, sign in your wallet.`, {
+        ctx.editMessageText(`✅ *Order Created!*\nTo complete the swap, sign in your wallet.\n\n🔔 *Auto-Watch Enabled:* I'll notify you when your swap completes!`, {
             parse_mode: 'Markdown',
             ...Markup.inlineKeyboard([
                 Markup.button.webApp('📱 Sign Transaction', `${MINI_APP_URL}?${params.toString()}`),
@@ -640,6 +736,9 @@ bot.action('place_portfolio_orders', async (ctx) => {
                     amount: quoteData.swapAmount
                 };
                 db.createOrderEntry(userId, orderCommand, order, quoteData.settleAmount, quoteData.quoteId);
+                
+                // Automatically add each order to watch list
+                await db.addWatchedOrder(userId, order.id, 'pending');
 
                 orders.push({ order, allocation: quoteData.allocation, quoteId: quoteData.quoteId });
             } catch (error) {
@@ -686,7 +785,7 @@ bot.action('place_portfolio_orders', async (ctx) => {
         orders.forEach((o, i) => {
             orderSummary += `${i + 1}. Order ${o.order.id.substring(0, 8)}... → ${o.allocation.toAsset}\n`;
         });
-        orderSummary += `\nSign the transaction to complete all swaps.`;
+        orderSummary += `\nSign the transaction to complete all swaps.\n\n🔔 *Auto-Watch Enabled:* I'll notify you when each swap completes!`;
 
         ctx.editMessageText(orderSummary, {
             parse_mode: 'Markdown',
@@ -710,4 +809,18 @@ bot.action('cancel_swap', (ctx) => {
 const app = express();
 app.get('/', (req, res) => res.send('SwapSmith Alive'));
 app.listen(process.env.PORT || 3000, () => console.log(`Express server live`));
+
+// Start the order monitor
+orderMonitor.start();
+
 bot.launch();
+
+// Graceful shutdown
+process.once('SIGINT', () => {
+    orderMonitor.stop();
+    bot.stop('SIGINT');
+});
+process.once('SIGTERM', () => {
+    orderMonitor.stop();
+    bot.stop('SIGTERM');
+});

--- a/bot/src/services/order-monitor.ts
+++ b/bot/src/services/order-monitor.ts
@@ -1,0 +1,150 @@
+import { Telegraf } from 'telegraf';
+import { getOrderStatus } from './sideshift-client';
+import * as db from './database';
+import { handleError } from './logger';
+
+const POLL_INTERVAL = 60000; // Check every 60 seconds
+const COMPLETED_STATUSES = ['settled', 'refunded'];
+
+export class OrderMonitor {
+  private bot: Telegraf;
+  private intervalId: NodeJS.Timeout | null = null;
+  private isRunning: boolean = false;
+
+  constructor(bot: Telegraf) {
+    this.bot = bot;
+  }
+
+  start() {
+    if (this.isRunning) {
+      console.log('⚠️ Order monitor is already running');
+      return;
+    }
+
+    console.log('🔍 Starting order monitor...');
+    this.isRunning = true;
+    
+    // Run immediately on start
+    this.checkOrders();
+    
+    // Then run on interval
+    this.intervalId = setInterval(() => {
+      this.checkOrders();
+    }, POLL_INTERVAL);
+  }
+
+  stop() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+    this.isRunning = false;
+    console.log('🛑 Order monitor stopped');
+  }
+
+  private async checkOrders() {
+    try {
+      const watchedOrders = await db.getAllWatchedOrders();
+      
+      if (watchedOrders.length === 0) {
+        return;
+      }
+
+      console.log(`🔍 Checking ${watchedOrders.length} watched orders...`);
+
+      for (const watchedOrder of watchedOrders) {
+        try {
+          await this.checkSingleOrder(watchedOrder);
+        } catch (error) {
+          console.error(`Error checking order ${watchedOrder.sideshiftOrderId}:`, error);
+          await handleError('OrderMonitorError', {
+            orderId: watchedOrder.sideshiftOrderId,
+            error: error instanceof Error ? error.message : 'Unknown error'
+          }, null, false);
+        }
+      }
+    } catch (error) {
+      console.error('Error in order monitor:', error);
+      await handleError('OrderMonitorError', {
+        error: error instanceof Error ? error.message : 'Unknown error'
+      }, null, false);
+    }
+  }
+
+  private async checkSingleOrder(watchedOrder: db.WatchedOrder) {
+    const { sideshiftOrderId, telegramId, lastStatus } = watchedOrder;
+
+    try {
+      const status = await getOrderStatus(sideshiftOrderId);
+      
+      // Update the order status in the orders table
+      await db.updateOrderStatus(sideshiftOrderId, status.status);
+
+      // Check if status has changed
+      if (status.status !== lastStatus) {
+        console.log(`📊 Order ${sideshiftOrderId} status changed: ${lastStatus} → ${status.status}`);
+        
+        // Update watched order status
+        await db.updateWatchedOrderStatus(sideshiftOrderId, status.status);
+
+        // Notify user of status change
+        await this.notifyUser(telegramId, sideshiftOrderId, status.status, status);
+
+        // If order is completed, remove from watch list
+        if (COMPLETED_STATUSES.includes(status.status.toLowerCase())) {
+          await db.removeWatchedOrder(sideshiftOrderId);
+          console.log(`✅ Order ${sideshiftOrderId} completed and removed from watch list`);
+        }
+      } else {
+        // Just update the last checked time
+        await db.updateWatchedOrderStatus(sideshiftOrderId, status.status);
+      }
+    } catch (error) {
+      console.error(`Failed to check order ${sideshiftOrderId}:`, error);
+      
+      // If order not found (404), remove from watch list
+      if (error instanceof Error && error.message.includes('not found')) {
+        await db.removeWatchedOrder(sideshiftOrderId);
+        console.log(`🗑️ Order ${sideshiftOrderId} not found, removed from watch list`);
+      }
+    }
+  }
+
+  private async notifyUser(telegramId: number, orderId: string, newStatus: string, statusData: any) {
+    try {
+      let message = `🔔 *Order Update*\n\n`;
+      message += `*Order ID:* \`${orderId}\`\n`;
+      message += `*Status:* \`${newStatus.toUpperCase()}\`\n\n`;
+
+      if (newStatus.toLowerCase() === 'settled') {
+        message += `✅ *Your swap is complete!*\n\n`;
+        message += `*Sent:* ${statusData.depositAmount || '?'} ${statusData.depositCoin} (${statusData.depositNetwork})\n`;
+        message += `*Received:* ${statusData.settleAmount || '?'} ${statusData.settleCoin} (${statusData.settleNetwork})\n`;
+        
+        if (statusData.settleHash) {
+          message += `*Transaction Hash:* \`${statusData.settleHash}\`\n`;
+        }
+        
+        message += `\n🎉 Funds have been delivered to your wallet!`;
+      } else if (newStatus.toLowerCase() === 'refunded') {
+        message += `⚠️ *Your swap was refunded*\n\n`;
+        message += `*Sent:* ${statusData.depositAmount || '?'} ${statusData.depositCoin}\n`;
+        
+        if (statusData.depositHash) {
+          message += `*Refund Hash:* \`${statusData.depositHash}\`\n`;
+        }
+        
+        message += `\nPlease check your wallet for the refunded amount.`;
+      } else if (newStatus.toLowerCase() === 'processing') {
+        message += `⏳ *Your swap is being processed*\n\n`;
+        message += `Deposit received and swap is in progress...`;
+      } else {
+        message += `Status changed to: *${newStatus}*`;
+      }
+
+      await this.bot.telegram.sendMessage(telegramId, message, { parse_mode: 'Markdown' });
+    } catch (error) {
+      console.error(`Failed to notify user ${telegramId}:`, error);
+    }
+  }
+}

--- a/bot/src/tests/order-monitor.test.ts
+++ b/bot/src/tests/order-monitor.test.ts
@@ -1,0 +1,214 @@
+import { OrderMonitor } from '../services/order-monitor';
+import * as db from '../services/database';
+import { getOrderStatus } from '../services/sideshift-client';
+import { Telegraf } from 'telegraf';
+
+// Mock dependencies
+jest.mock('../services/database');
+jest.mock('../services/sideshift-client');
+jest.mock('../services/logger');
+
+describe('OrderMonitor', () => {
+  let mockBot: any;
+  let orderMonitor: OrderMonitor;
+
+  beforeEach(() => {
+    // Create mock bot with telegram.sendMessage
+    mockBot = {
+      telegram: {
+        sendMessage: jest.fn().mockResolvedValue({}),
+      },
+    };
+
+    orderMonitor = new OrderMonitor(mockBot as Telegraf);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    orderMonitor.stop();
+  });
+
+  describe('Order Status Monitoring', () => {
+    it('should detect status change from pending to settled', async () => {
+      const mockWatchedOrder = {
+        id: 1,
+        telegramId: 123456,
+        sideshiftOrderId: 'test-order-123',
+        lastStatus: 'pending',
+        lastChecked: new Date(),
+        createdAt: new Date(),
+      };
+
+      const mockOrderStatus = {
+        id: 'test-order-123',
+        status: 'settled',
+        depositCoin: 'ETH',
+        depositNetwork: 'ethereum',
+        settleCoin: 'USDC',
+        settleNetwork: 'polygon',
+        depositAddress: { address: '0xabc...', memo: null },
+        settleAddress: { address: '0xdef...', memo: null },
+        depositAmount: '1.0',
+        settleAmount: '2500.0',
+        depositHash: '0x123...',
+        settleHash: '0x456...',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+
+      (db.getAllWatchedOrders as jest.Mock).mockResolvedValue([mockWatchedOrder]);
+      (getOrderStatus as jest.Mock).mockResolvedValue(mockOrderStatus);
+      (db.updateOrderStatus as jest.Mock).mockResolvedValue(undefined);
+      (db.updateWatchedOrderStatus as jest.Mock).mockResolvedValue(undefined);
+      (db.removeWatchedOrder as jest.Mock).mockResolvedValue(undefined);
+
+      // Manually trigger check
+      await (orderMonitor as any).checkOrders();
+
+      // Verify status was updated
+      expect(db.updateOrderStatus).toHaveBeenCalledWith('test-order-123', 'settled');
+      expect(db.updateWatchedOrderStatus).toHaveBeenCalledWith('test-order-123', 'settled');
+
+      // Verify user was notified
+      expect(mockBot.telegram.sendMessage).toHaveBeenCalledWith(
+        123456,
+        expect.stringContaining('Your swap is complete'),
+        expect.any(Object)
+      );
+
+      // Verify order was removed from watch list
+      expect(db.removeWatchedOrder).toHaveBeenCalledWith('test-order-123');
+    });
+
+    it('should not notify if status has not changed', async () => {
+      const mockWatchedOrder = {
+        id: 1,
+        telegramId: 123456,
+        sideshiftOrderId: 'test-order-123',
+        lastStatus: 'pending',
+        lastChecked: new Date(),
+        createdAt: new Date(),
+      };
+
+      const mockOrderStatus = {
+        id: 'test-order-123',
+        status: 'pending',
+        depositCoin: 'ETH',
+        depositNetwork: 'ethereum',
+        settleCoin: 'USDC',
+        settleNetwork: 'polygon',
+        depositAddress: { address: '0xabc...', memo: null },
+        settleAddress: { address: '0xdef...', memo: null },
+        depositAmount: null,
+        settleAmount: null,
+        depositHash: null,
+        settleHash: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+
+      (db.getAllWatchedOrders as jest.Mock).mockResolvedValue([mockWatchedOrder]);
+      (getOrderStatus as jest.Mock).mockResolvedValue(mockOrderStatus);
+      (db.updateOrderStatus as jest.Mock).mockResolvedValue(undefined);
+      (db.updateWatchedOrderStatus as jest.Mock).mockResolvedValue(undefined);
+
+      await (orderMonitor as any).checkOrders();
+
+      // Verify status was updated but user was not notified
+      expect(db.updateWatchedOrderStatus).toHaveBeenCalledWith('test-order-123', 'pending');
+      expect(mockBot.telegram.sendMessage).not.toHaveBeenCalled();
+      expect(db.removeWatchedOrder).not.toHaveBeenCalled();
+    });
+
+    it('should handle refunded orders', async () => {
+      const mockWatchedOrder = {
+        id: 1,
+        telegramId: 123456,
+        sideshiftOrderId: 'test-order-123',
+        lastStatus: 'pending',
+        lastChecked: new Date(),
+        createdAt: new Date(),
+      };
+
+      const mockOrderStatus = {
+        id: 'test-order-123',
+        status: 'refunded',
+        depositCoin: 'ETH',
+        depositNetwork: 'ethereum',
+        settleCoin: 'USDC',
+        settleNetwork: 'polygon',
+        depositAddress: { address: '0xabc...', memo: null },
+        settleAddress: { address: '0xdef...', memo: null },
+        depositAmount: '1.0',
+        settleAmount: null,
+        depositHash: '0x123...',
+        settleHash: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+
+      (db.getAllWatchedOrders as jest.Mock).mockResolvedValue([mockWatchedOrder]);
+      (getOrderStatus as jest.Mock).mockResolvedValue(mockOrderStatus);
+      (db.updateOrderStatus as jest.Mock).mockResolvedValue(undefined);
+      (db.updateWatchedOrderStatus as jest.Mock).mockResolvedValue(undefined);
+      (db.removeWatchedOrder as jest.Mock).mockResolvedValue(undefined);
+
+      await (orderMonitor as any).checkOrders();
+
+      // Verify user was notified about refund
+      expect(mockBot.telegram.sendMessage).toHaveBeenCalledWith(
+        123456,
+        expect.stringContaining('Your swap was refunded'),
+        expect.any(Object)
+      );
+
+      // Verify order was removed from watch list
+      expect(db.removeWatchedOrder).toHaveBeenCalledWith('test-order-123');
+    });
+
+    it('should remove order from watch list if not found', async () => {
+      const mockWatchedOrder = {
+        id: 1,
+        telegramId: 123456,
+        sideshiftOrderId: 'test-order-123',
+        lastStatus: 'pending',
+        lastChecked: new Date(),
+        createdAt: new Date(),
+      };
+
+      (db.getAllWatchedOrders as jest.Mock).mockResolvedValue([mockWatchedOrder]);
+      (getOrderStatus as jest.Mock).mockRejectedValue(new Error('Order not found'));
+      (db.removeWatchedOrder as jest.Mock).mockResolvedValue(undefined);
+
+      await (orderMonitor as any).checkOrders();
+
+      // Verify order was removed from watch list
+      expect(db.removeWatchedOrder).toHaveBeenCalledWith('test-order-123');
+    });
+  });
+
+  describe('Monitor Lifecycle', () => {
+    it('should start and stop monitoring', () => {
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+      orderMonitor.start();
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Starting order monitor'));
+
+      orderMonitor.stop();
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Order monitor stopped'));
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should not start if already running', () => {
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+      orderMonitor.start();
+      orderMonitor.start(); // Try to start again
+
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('already running'));
+
+      consoleSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Description

Implements persistent transaction monitoring for the Telegram bot. Users now receive automatic push notifications when their cross-chain swaps complete, eliminating the need to manually check order status.

## Related Issue

Closes #60

### Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test addition/update

## Changes Made

- **Auto-watch orders**: Orders automatically added to watch list when created
- **Real-time notifications**: Push notifications sent when order status changes
- **Manual controls**: Added `/watch`, `/unwatch`, `/watching` commands
- **Background monitoring**: Service polls SideShift API every 60 seconds
- **Smart cleanup**: Completed orders automatically removed from watch list
- **Database migration**: New `watched_orders` table for persistent storage
- **Unit tests**: Comprehensive test coverage for monitoring service

**Files Changed:**
- `bot/src/bot.ts` - Added watch commands and auto-watch integration
- `bot/src/services/database.ts` - Added watched orders table and functions
- `bot/src/services/order-monitor.ts` - Background monitoring service
- `bot/src/tests/order-monitor.test.ts` - Unit tests
- `bot/drizzle/0003_persistent_transaction_monitoring.sql` - Database migration

---


## Screenshots/Demo (if applicable)

![WhatsApp Image 2026-02-09 at 6 13 28 PM](https://github.com/user-attachments/assets/477d4694-b8cb-4a0c-9c6c-2cef54d5facd)

![WhatsApp Image 2026-02-09 at 6 13 29 PM (1)](https://github.com/user-attachments/assets/03a62f90-efe9-429c-a01a-b542dba94c43)

![WhatsApp Image 2026-02-09 at 6 13 29 PM (2)](https://github.com/user-attachments/assets/77f1d54a-eb1e-4945-b2e3-6236e1d7fdfa)

![WhatsApp Image 2026-02-09 at 6 13 29 PM](https://github.com/user-attachments/assets/26cc2fab-6538-4e08-947f-8977199b6b76)

![WhatsApp Image 2026-02-09 at 6 13 30 PM (1)](https://github.com/user-attachments/assets/088ce58f-a638-4349-b9ce-2f68f06c475a)

![WhatsApp Image 2026-02-09 at 6 13 30 PM (2)](https://github.com/user-attachments/assets/3453bc9b-063a-42bd-973d-a36374eb5c2f)

![WhatsApp Image 2026-02-09 at 6 13 30 PM](https://github.com/user-attachments/assets/44a3da0c-294a-4ef0-a994-155e00c109e4)

![WhatsApp Image 2026-02-09 at 6 13 31 PM (1)](https://github.com/user-attachments/assets/38deea06-ebb4-486a-b93b-41a42f991ace)

![WhatsApp Image 2026-02-09 at 6 13 31 PM (2)](https://github.com/user-attachments/assets/20a7052b-2140-4d5f-8615-63abf0aa5693)

![WhatsApp Image 2026-02-09 at 6 13 31 PM](https://github.com/user-attachments/assets/4885023a-6ef2-42e4-96dc-c234ac470e12)

![WhatsApp Image 2026-02-09 at 8 02 48 PM](https://github.com/user-attachments/assets/442ed98d-eb9d-47d3-845d-53e8e216c01b)


## Testing Done

- [x] Tested locally (npm run dev)
- [x] No TypeScript errors
- [x] Created test swaps and verified auto-watch functionality
- [x] Verified notifications sent when order status changes
- [x] Tested manual watch/unwatch commands
- [x] Unit tests pass

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [x] Any dependent changes have been merged and published

## Additional Notes

**Technical Details:**
- Monitoring service runs in background with 60-second polling interval
- Graceful shutdown handling ensures monitor stops cleanly
- Compatible with recently merged multi-asset basket swaps feature
- No breaking changes to existing functionality

---

**By submitting this PR, I confirm that:**
- I have read and followed the [Contributing Guidelines](../CONTRIBUTING.md)
- I have read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
- This contribution is my own work and I have the right to license it
