### PR TITLE
feat: Implement browser compatibility layer for voice input (Issue #58)

### DIFF
--- a/frontend/components/ChatInterface.tsx
+++ b/frontend/components/ChatInterface.tsx
@@ -112,7 +112,6 @@ export default function ChatInterface() {
     }
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const _handleStopRecording = async () => {
     try {
       const audioBlob = await stopRecording();
@@ -436,7 +435,7 @@ return (
           
           <div className="relative flex items-center gap-3 bg-[#161A1E] border border-white/10 p-2 rounded-2xl group-focus-within:border-blue-500/50 transition-all">
             <button 
-              onClick={isRecording ? stopRecording : startRecording}
+              onClick={isRecording ? _handleStopRecording : startRecording}
               className={`p-3 rounded-xl transition-all ${
                 isRecording ? 'bg-red-500 text-white animate-pulse shadow-lg shadow-red-500/40' : 'bg-white/5 text-gray-400 hover:bg-white/10'
               }`}

--- a/frontend/hooks/useAudioRecorder.ts
+++ b/frontend/hooks/useAudioRecorder.ts
@@ -15,22 +15,134 @@ export interface UseAudioRecorderReturn {
     browser: string;
     supportedMimeTypes: string[];
     recommendedMimeType: string;
+    isFallback: boolean;
   };
 }
 
-// Cross-browser audio recording polyfill
+// Helper to write string to DataView
+function writeString(view: DataView, offset: number, string: string) {
+  for (let i = 0; i < string.length; i++) {
+    view.setUint8(offset + i, string.charCodeAt(i));
+  }
+}
+
+// Helper to encode Float32 samples to 16-bit PCM
+function floatTo16BitPCM(output: DataView, offset: number, input: Float32Array) {
+  for (let i = 0; i < input.length; i++, offset += 2) {
+    const s = Math.max(-1, Math.min(1, input[i]));
+    output.setInt16(offset, (s < 0 ? s * 0x8000 : s * 0x7FFF), true);
+  }
+}
+
+// WAV Encoder
+function encodeWAV(samples: Float32Array, sampleRate: number): Blob {
+  const buffer = new ArrayBuffer(44 + samples.length * 2);
+  const view = new DataView(buffer);
+
+  /* RIFF identifier */
+  writeString(view, 0, 'RIFF');
+  /* RIFF chunk length */
+  view.setUint32(4, 36 + samples.length * 2, true);
+  /* RIFF type */
+  writeString(view, 8, 'WAVE');
+  /* format chunk identifier */
+  writeString(view, 12, 'fmt ');
+  /* format chunk length */
+  view.setUint32(16, 16, true);
+  /* sample format (raw) */
+  view.setUint16(20, 1, true);
+  /* channel count */
+  view.setUint16(22, 1, true);
+  /* sample rate */
+  view.setUint32(24, sampleRate, true);
+  /* byte rate (sample rate * block align) */
+  view.setUint32(28, sampleRate * 2, true);
+  /* block align (channel count * bytes per sample) */
+  view.setUint16(32, 2, true);
+  /* bits per sample */
+  view.setUint16(34, 16, true);
+  /* data chunk identifier */
+  writeString(view, 36, 'data');
+  /* data chunk length */
+  view.setUint32(40, samples.length * 2, true);
+
+  floatTo16BitPCM(view, 44, samples);
+
+  return new Blob([view], { type: 'audio/wav' });
+}
+
+// Fallback Recorder using Web Audio API
+class WebAudioRecorder {
+  private context: AudioContext | null = null;
+  private processor: ScriptProcessorNode | null = null;
+  private input: MediaStreamAudioSourceNode | null = null;
+  private chunks: Float32Array[] = [];
+  private stream: MediaStream;
+  private sampleRate: number;
+
+  constructor(stream: MediaStream, config: AudioRecorderConfig) {
+    this.stream = stream;
+    this.sampleRate = config.sampleRate || 16000;
+  }
+
+  start() {
+    const AudioContextClass = window.AudioContext || (window as any).webkitAudioContext;
+    this.context = new AudioContextClass({ sampleRate: this.sampleRate });
+    this.input = this.context.createMediaStreamSource(this.stream);
+    
+    // bufferSize 4096 is a good balance between latency and performance
+    this.processor = this.context.createScriptProcessor(4096, 1, 1);
+
+    this.processor.onaudioprocess = (e) => {
+      const channelData = e.inputBuffer.getChannelData(0);
+      // Clone the data since the buffer is reused
+      this.chunks.push(new Float32Array(channelData));
+    };
+
+    this.input.connect(this.processor);
+    this.processor.connect(this.context.destination);
+  }
+
+  async stop(): Promise<Blob> {
+    if (this.processor && this.input && this.context) {
+       this.input.disconnect();
+       this.processor.disconnect();
+       if (this.context.state !== 'closed') {
+         await this.context.close();
+       }
+    }
+
+    // Determine total length
+    const totalLength = this.chunks.reduce((acc, chunk) => acc + chunk.length, 0);
+    const result = new Float32Array(totalLength);
+    
+    // Flatten chunks
+    let offset = 0;
+    for (const chunk of this.chunks) {
+      result.set(chunk, offset);
+      offset += chunk.length;
+    }
+
+    return encodeWAV(result, this.context?.sampleRate || this.sampleRate);
+  }
+}
+
+// Cross-browser audio recording wrapper
 class AudioRecorderPolyfill {
   private mediaRecorder: MediaRecorder | null = null;
+  private webAudioRecorder: WebAudioRecorder | null = null;
   private audioChunks: Blob[] = [];
   private stream: MediaStream | null = null;
   private mimeType: string = '';
   private browser: string = 'unknown';
+  private useFallback: boolean = false;
 
   constructor() {
     this.detectBrowser();
   }
 
   private detectBrowser(): void {
+    if (typeof navigator === 'undefined') return;
     const userAgent = navigator.userAgent;
     
     if (userAgent.includes('Chrome') && !userAgent.includes('Edg')) {
@@ -45,18 +157,15 @@ class AudioRecorderPolyfill {
   }
 
   private getBestMimeType(): string {
-    // Browser-specific MIME type selection with fallbacks
     const mimeTypesByBrowser = {
       chrome: [
         'audio/webm;codecs=opus',
         'audio/webm',
-        'audio/mp4',
         'audio/wav'
       ],
       firefox: [
         'audio/ogg;codecs=opus',
         'audio/ogg',
-        'audio/webm;codecs=opus',
         'audio/webm',
         'audio/wav'
       ],
@@ -68,17 +177,15 @@ class AudioRecorderPolyfill {
       edge: [
         'audio/webm;codecs=opus',
         'audio/webm',
-        'audio/mp4',
         'audio/wav'
       ]
     };
 
     const browserMimeTypes = mimeTypesByBrowser[this.browser as keyof typeof mimeTypesByBrowser] || mimeTypesByBrowser.chrome;
 
-    // Find first supported MIME type
     for (const mimeType of browserMimeTypes) {
       try {
-        if (MediaRecorder.isTypeSupported && MediaRecorder.isTypeSupported(mimeType)) {
+        if (typeof MediaRecorder !== 'undefined' && MediaRecorder.isTypeSupported && MediaRecorder.isTypeSupported(mimeType)) {
           return mimeType;
         }
       } catch {
@@ -86,7 +193,6 @@ class AudioRecorderPolyfill {
       }
     }
 
-    // Ultimate fallback - let browser choose
     return '';
   }
 
@@ -101,17 +207,12 @@ class AudioRecorderPolyfill {
       }
     };
 
-    // Browser-specific optimizations
     if (this.browser === 'safari') {
-      // Safari-specific optimizations
       const audioConstraints = baseConstraints.audio as MediaTrackConstraints;
       baseConstraints.audio = {
         ...audioConstraints,
-        sampleRate: 44100 // Safari prefers higher sample rates
+        sampleRate: 44100
       };
-    } else if (this.browser === 'firefox') {
-      // Firefox-specific optimizations - keep base constraints
-      // Firefox works well with the base configuration
     }
 
     return baseConstraints;
@@ -119,44 +220,48 @@ class AudioRecorderPolyfill {
 
   async startRecording(config: AudioRecorderConfig = {}): Promise<void> {
     try {
-      // Get optimal audio constraints for this browser
+      this.useFallback = typeof window.MediaRecorder === 'undefined';
       const constraints = this.getOptimalConstraints(config);
-      
-      // Request microphone access
       this.stream = await navigator.mediaDevices.getUserMedia(constraints);
-      
-      // Get best MIME type for this browser
-      this.mimeType = this.getBestMimeType();
-      
-      // Create MediaRecorder with browser-specific options
-      const options: MediaRecorderOptions = {};
-      if (this.mimeType) {
-        options.mimeType = this.mimeType;
-      }
 
-      // Browser-specific MediaRecorder options
-      if (this.browser === 'safari') {
-        options.audioBitsPerSecond = 128000;
-      } else if (this.browser === 'firefox') {
-        options.audioBitsPerSecond = 128000;
-      } else if (this.browser === 'chrome' || this.browser === 'edge') {
-        options.audioBitsPerSecond = 128000;
-      }
-
-      this.mediaRecorder = new MediaRecorder(this.stream, options);
-      this.audioChunks = [];
-
-      // Set up event handlers
-      this.mediaRecorder.ondataavailable = (event: BlobEvent) => {
-        if (event.data.size > 0) {
-          this.audioChunks.push(event.data);
+      if (this.useFallback) {
+        // Use Web Audio API Fallback
+        this.webAudioRecorder = new WebAudioRecorder(this.stream, config);
+        this.webAudioRecorder.start();
+      } else {
+        // Use Native MediaRecorder
+        this.mimeType = this.getBestMimeType();
+        const options: MediaRecorderOptions = {};
+        if (this.mimeType) {
+          options.mimeType = this.mimeType;
         }
-      };
 
-      // Start recording with appropriate time slice
-      const timeSlice = this.browser === 'safari' ? 100 : 1000;
-      this.mediaRecorder.start(timeSlice);
+        // Bitrate tweaks
+        if (['safari', 'firefox', 'chrome', 'edge'].includes(this.browser)) {
+          options.audioBitsPerSecond = 128000;
+        }
 
+        try {
+          this.mediaRecorder = new MediaRecorder(this.stream, options);
+        } catch (e) {
+          // If native MediaRecorder fails creation despite check, fallback
+          console.warn("MediaRecorder failed to initialize, switching to fallback", e);
+          this.useFallback = true;
+          this.webAudioRecorder = new WebAudioRecorder(this.stream, config);
+          this.webAudioRecorder.start();
+          return;
+        }
+
+        this.audioChunks = [];
+        this.mediaRecorder.ondataavailable = (event: BlobEvent) => {
+          if (event.data.size > 0) {
+            this.audioChunks.push(event.data);
+          }
+        };
+
+        const timeSlice = this.browser === 'safari' ? 100 : 1000;
+        this.mediaRecorder.start(timeSlice);
+      }
     } catch (error) {
       this.cleanup();
       throw error;
@@ -164,22 +269,26 @@ class AudioRecorderPolyfill {
   }
 
   async stopRecording(): Promise<Blob | null> {
-    if (!this.mediaRecorder || this.mediaRecorder.state === 'inactive') {
-      return null;
+    if (this.useFallback) {
+      if (!this.webAudioRecorder) return null;
+      const blob = await this.webAudioRecorder.stop();
+      this.cleanup();
+      return blob;
+    } else {
+      if (!this.mediaRecorder || this.mediaRecorder.state === 'inactive') {
+        return null;
+      }
+
+      return new Promise((resolve) => {
+        this.mediaRecorder!.onstop = () => {
+          const finalMimeType = this.mimeType || 'audio/webm';
+          const audioBlob = new Blob(this.audioChunks, { type: finalMimeType });
+          this.cleanup();
+          resolve(audioBlob);
+        };
+        this.mediaRecorder!.stop();
+      });
     }
-
-    return new Promise((resolve) => {
-      this.mediaRecorder!.onstop = () => {
-        // Create blob with detected MIME type or fallback
-        const finalMimeType = this.mimeType || 'audio/webm';
-        const audioBlob = new Blob(this.audioChunks, { type: finalMimeType });
-        
-        this.cleanup();
-        resolve(audioBlob);
-      };
-
-      this.mediaRecorder!.stop();
-    });
   }
 
   private cleanup(): void {
@@ -188,19 +297,23 @@ class AudioRecorderPolyfill {
       this.stream = null;
     }
     this.mediaRecorder = null;
+    this.webAudioRecorder = null;
     this.audioChunks = [];
   }
 
   isSupported(): boolean {
+    if (typeof navigator === 'undefined' || !navigator.mediaDevices || typeof navigator.mediaDevices.getUserMedia !== 'function') {
+      return false;
+    }
+    // Supported if MediaRecorder exists OR AudioContext exists
     return !!(
-      navigator.mediaDevices &&
-      typeof navigator.mediaDevices.getUserMedia === 'function' &&
-      window.MediaRecorder
+      (typeof window !== 'undefined' && window.MediaRecorder) || 
+      (typeof window !== 'undefined' && (window.AudioContext || (window as any).webkitAudioContext))
     );
   }
 
   getBrowserInfo() {
-    const supportedMimeTypes = [
+    const supportedMimeTypes = typeof MediaRecorder !== 'undefined' ? [
       'audio/webm;codecs=opus',
       'audio/webm',
       'audio/mp4',
@@ -213,12 +326,13 @@ class AudioRecorderPolyfill {
       } catch {
         return false;
       }
-    });
+    }) : ['audio/wav']; // Fallback supports WAV
 
     return {
       browser: this.browser,
       supportedMimeTypes,
-      recommendedMimeType: this.getBestMimeType()
+      recommendedMimeType: this.getBestMimeType(),
+      isFallback: typeof window !== 'undefined' && !window.MediaRecorder
     };
   }
 }
@@ -230,10 +344,12 @@ export const useAudioRecorder = (config: AudioRecorderConfig = {}): UseAudioReco
     browser: string;
     supportedMimeTypes: string[];
     recommendedMimeType: string;
+    isFallback: boolean;
   }>({
     browser: 'unknown',
     supportedMimeTypes: [],
-    recommendedMimeType: ''
+    recommendedMimeType: '',
+    isFallback: false
   });
   const [isSupported, setIsSupported] = useState(false);
   const polyfillRef = useRef<AudioRecorderPolyfill | null>(null);
@@ -260,6 +376,8 @@ export const useAudioRecorder = (config: AudioRecorderConfig = {}): UseAudioReco
       setError(null);
       await polyfillRef.current.startRecording(config);
       setIsRecording(true);
+      // Update browser info in case fallback was triggered during start
+      setBrowserInfo(polyfillRef.current.getBrowserInfo());
     } catch (err: unknown) {
       console.error('Failed to start recording:', err);
       
@@ -273,6 +391,7 @@ export const useAudioRecorder = (config: AudioRecorderConfig = {}): UseAudioReco
       } else {
         setError(`Failed to start recording: ${error.message || 'Unknown error'}`);
       }
+      setIsRecording(false);
     }
   }, [isSupported, isRecording, config]);
 


### PR DESCRIPTION
## Description
This PR implements a robust fallback mechanism for audio recording to ensure compatibility across all major browsers (Safari, Edge, Firefox, Chrome). It replaces the reliance on `MediaRecorder` with a manual `WebAudioAPI` implementation that encodes to WAV when native recording is unavailable or unstable.

## Changes
- **`frontend/hooks/useAudioRecorder.ts`**:
  - Introduced `WebAudioRecorder` class using `AudioContext` and `ScriptProcessorNode`.
  - Added `encodeWAV` utility for raw PCM to WAV conversion.
  - Refactored `AudioRecorderPolyfill` to auto-detect browser capabilities and switch strategies.
- **`frontend/components/ChatInterface.tsx`**:
  - Fixed a bug where `stopRecording` output was ignored.
  - Wired up `_handleStopRecording` to correctly process the audio blob.

## Testing
- Verified simple `MediaRecorder` usage on Chrome.
- Verified `WebAudioAPI` fallback on environments simulating lack of `MediaRecorder`.
- Confirmed voice commands are successfully sent to the backend.

Closes #58