### PR TITLE
fix(chat): route mic button through wrapper handlers to restore error handling and user feedback

### DIFF
--- a/frontend/components/ChatInterface.tsx
+++ b/frontend/components/ChatInterface.tsx
@@ -90,7 +90,6 @@ export default function ChatInterface() {
   };
 
   // Voice recording handlers (reserved for future UI integration)
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const _handleStartRecording = async () => {
     if (!isAudioSupported) {
       addMessage({ 
@@ -435,7 +434,13 @@ return (
           
           <div className="relative flex items-center gap-3 bg-[#161A1E] border border-white/10 p-2 rounded-2xl group-focus-within:border-blue-500/50 transition-all">
             <button 
-              onClick={isRecording ? _handleStopRecording : startRecording}
+              onClick={() => {
+                if (isRecording) {
+                  _handleStopRecording();
+                } else {
+                  _handleStartRecording();
+                }
+              }}
               className={`p-3 rounded-xl transition-all ${
                 isRecording ? 'bg-red-500 text-white animate-pulse shadow-lg shadow-red-500/40' : 'bg-white/5 text-gray-400 hover:bg-white/10'
               }`}


### PR DESCRIPTION
Fixes issue where microphone button bypassed wrapper error handlers. 
Updated onClick to use _handleStartRecording and _handleStopRecording instead of raw hook methods. 
This restores proper error handling and user feedback in case of mic permission denial or recording failure.