### PR TITLE
added startup check for ffmpeg dependency before bot launch ( Fixes #188)

### DIFF
--- a/bot/src/bot.ts
+++ b/bot/src/bot.ts
@@ -59,6 +59,16 @@ function isValidAddress(address: string, chain?: string): boolean {
     return pattern ? pattern.test(trimmed) : DEFAULT_EVM_PATTERN.test(trimmed);
 }
 
+function checkFFmpeg(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    exec('ffmpeg -version', (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+
 // --------------------------------------------------
 // ORDER MONITOR
 // --------------------------------------------------
@@ -316,11 +326,21 @@ app.get('/', (_, res) => res.send('SwapSmith Alive'));
 app.listen(process.env.PORT || 3000);
 
 (async () => {
-    await orderMonitor.loadPendingOrders();
-    orderMonitor.start();
-    bot.launch();
-    console.log('🤖 Bot running');
+  try {
+    await checkFFmpeg();
+    console.log('✅ ffmpeg is installed. Voice messages enabled.');
+  } catch {
+    console.error('❌ ffmpeg not found. Install ffmpeg to enable voice message support.');
+    process.exit(1); 
+  }
+
+  await orderMonitor.loadPendingOrders();
+  orderMonitor.start();
+
+  await bot.launch();
+  console.log('🤖 Bot running');
 })();
+
 
 process.once('SIGINT', () => bot.stop('SIGINT'));
 process.once('SIGTERM', () => bot.stop('SIGTERM'));


### PR DESCRIPTION
<----SUMMARY---->
This PR adds an async startup check to verify that ffmpeg is installed before launching the Telegram bot.

<-------What was added---------->
1) Introduced a checkFFmpeg() helper using child_process.exec
2) Runs ffmpeg -version before bot.launch()
3) If FFmpeg is missing:
    Logs a clear error message
    Exits the process safely (process.exit(1))
    Ensures the check is asynchronous (no execSync used)

<----Testing---->
Case 1 – FFmpeg Installed
   Bot starts normally
   Logs: ✅ ffmpeg is installed. Voice messages enabled.
   Bot launches successfully
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/e5772973-90c1-477f-a0b1-8812566e5af5" />


Case 2 – FFmpeg Missing (Simulated)
  Temporarily changed command to ffmpeg___ -version
  Bot logs error message
  Process exits before bot.launch()
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/2af2fecd-3ed1-4a60-8dca-07cf6ef10dd3" />


Now let me know if any changes needed still.