### PR TITLE
add custom docker network and attach services (resolve #120)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,8 @@ services:
     env_file:
       - ./frontend/.env
     restart: unless-stopped
+    networks:
+      - swapsmith-net
   
   bot:
     build:
@@ -26,6 +28,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    networks:
+      - swapsmith-net
 
   db:
     image: postgres:15
@@ -43,7 +47,13 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    networks:
+      - swapsmith-net
 
 
 volumes:
   postgres_data:
+
+networks:
+  swapsmith-net:
+    driver: bridge

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -3,7 +3,7 @@ node_modules
 .git
 .gitignore
 Dockerfile
-docker-compose.yml
+
 npm-debug.log
 .env
 coverage


### PR DESCRIPTION
=> This PR resolves the "No networks defined" issue by explicitly defining a custom Docker network and attaching all services (frontend, bot, and db) to it.

=>Changes made=>
  1) Added a custom network: swapsmith-net
  2) Attached frontend, bot, and db services to this network
  3) Ensured database healthcheck works correctly
  4) Verified containers communicate successfully
  5) Confirmed no more "No networks defined" issue

=>Testing=>
  docker compose -f docker-compose.yaml up -d --build
  docker compose -f docker-compose.yaml ps
<---confirmed--->
  Confirmed:
   swapsmith-db → running (healthy)
   swapsmith-bot → running
   swapsmith-frontend → running
   Custom network created and attached successfully
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/5ea52d6d-bd9a-4f27-b373-9a02c7e42b51" />

