### PR TITLE
Inconsistent Error Handling with Empty Catch Blocks

### DIFF
--- a/bot/src/services/groq-client.ts
+++ b/bot/src/services/groq-client.ts
@@ -1,7 +1,8 @@
 import Groq from "groq-sdk";
 import dotenv from 'dotenv';
 import fs from 'fs';
-import { handleError } from './logger';
+import logger, { handleError } from './logger';
+
 import { analyzeCommand, generateContextualHelp } from './contextual-help';
 
 dotenv.config();
@@ -224,7 +225,15 @@ function validateParsedCommand(parsed: Partial<ParsedCommand>, userInput: string
           const analysis = analyzeCommand(result);
           const help = generateContextualHelp(analysis, userInput, inputType);
           result.validationErrors.push(help);
-      } catch (e) { console.error("Help Gen Failed", e); }
+      } catch (e) { 
+          logger.error('ContextualHelpGenerationError', {
+              error: e instanceof Error ? e.message : 'Unknown error',
+              stack: e instanceof Error ? e.stack : undefined,
+              operation: 'generateContextualHelp',
+              parsedCommand: result
+          });
+      }
+
   }
 
   return result;


### PR DESCRIPTION
## Changes Made:
1. bot/src/workers/limitOrderWorker.ts
Added import: import logger, { handleError } from '../services/logger';
Fixed empty catch block: Replaced } catch (e) {} with proper error handling using handleError() function
Error context includes: error message, stack trace, order ID, telegram ID, and descriptive message
Admin alerts: Enabled (sendAlert: true) to notify admins via Telegram when failure notifications can't be sent
2. bot/src/services/groq-client.ts
Updated import: Changed to import logger, { handleError } from './logger';
Fixed minimal error handling: Replaced console.error("Help Gen Failed", e) with proper Winston logger usage
Error context includes: error message, stack trace, operation name ('generateContextualHelp'), and the parsed command that caused the error
## Verification:
Search for empty catch blocks returned 0 results - all instances have been fixed
Both files now use the proper Winston logger infrastructure
Errors are properly logged with full context including stack traces
Critical errors will send admin alerts via Telegram using handleError()

closes #204