### PR TITLE
UX: Auto-focus text input on voice recording failure 

### DIFF
--- a/frontend/components/ChatInterface.tsx
+++ b/frontend/components/ChatInterface.tsx
@@ -51,6 +51,7 @@ export default function ChatInterface() {
   const [pendingCommand, setPendingCommand] = useState<ParsedCommand | null>(null);
   
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const { address, isConnected } = useAccount();
   const { handleError } = useErrorHandler();
   
@@ -70,10 +71,11 @@ export default function ChatInterface() {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
-  // Show audio error if any
+  // Show audio error if any, and refocus text input so the user can type
   useEffect(() => {
     if (audioError) {
       addMessage({ role: 'assistant', content: audioError, type: 'message' });
+      inputRef.current?.focus();
     }
   }, [audioError]);
 
@@ -98,6 +100,7 @@ export default function ChatInterface() {
         content: `Voice input is not supported in this browser. Please use text input instead.`, 
         type: 'message' 
       });
+      inputRef.current?.focus();
       return;
     }
 
@@ -109,6 +112,7 @@ export default function ChatInterface() {
         retryable: true 
       });
       addMessage({ role: 'assistant', content: errorMessage, type: 'message' });
+      inputRef.current?.focus();
     }
   };
 
@@ -124,6 +128,7 @@ export default function ChatInterface() {
         retryable: true 
       });
       addMessage({ role: 'assistant', content: errorMessage, type: 'message' });
+      inputRef.current?.focus();
     }
   };
 
@@ -182,6 +187,7 @@ export default function ChatInterface() {
         setMessages(prev => prev.filter(m => m.content !== '🎤 [Sending Voice...]'));
         addMessage({ role: 'assistant', content: errorMessage, type: 'message' });
         setIsLoading(false);
+        inputRef.current?.focus();
     }
   };
 
@@ -444,6 +450,7 @@ return (
             </button>
             
             <input
+              ref={inputRef}
               type="text"
               value={input}
               onChange={(e) => setInput(e.target.value)}


### PR DESCRIPTION
This PR improves chat UX by automatically focusing the text input whenever voice recording fails. Previously, the UI displayed an error message but left focus inactive, forcing users to manually click the input field before typing.

This change ensures a smooth fallback from voice to text input.

## Problem Statement
When voice recording fails (due to unsupported browser, mic access denial, transcription error, etc.):

- An error message is shown.
- The input field is not focused.
- Users must manually click the input to continue typing.
- This creates friction and interrupts conversation flow.

## Solution
- Introduced a `useRef<HTMLInputElement>` to track the text input.
- Wired the ref to the `<input>` element.
- Triggered `inputRef.current?.focus()` in every voice failure path.

## Changes Made

### 1. Added Input Ref
**File:** `frontend/components/ChatInterface.tsx`

```ts
const inputRef = useRef<HTMLInputElement>(null);