### PR TITLE
feat: integrate natural language limit orders (#184)

### DIFF
--- a/bot/src/services/__tests__/limit-order-parsing.test.ts
+++ b/bot/src/services/__tests__/limit-order-parsing.test.ts
@@ -1,0 +1,48 @@
+// Helper to mock environment variables if needed
+process.env.GROQ_API_KEY = 'dummy-key'; 
+
+jest.mock('../groq-client', () => ({
+    ParsedCommand: {},
+    parseWithLLM: jest.fn(),
+}));
+
+import { parseUserCommand } from '../parseUserCommand';
+
+describe('Limit Order Parsing', () => {
+    it('should detect limit order intent with "drops below"', async () => {
+        const result = await parseUserCommand('Swap 100 USDC to ETH when ETH drops below 2000');
+        // Success check
+        expect(result.success).toBe(true);
+        
+        // Only verify fields if success is true to avoid TS errors
+        if ('intent' in result) {
+            expect(result.intent).toBe('limit_order');
+            expect(result.fromAsset).toBe('USDC');
+            expect(result.toAsset).toBe('ETH');
+            expect(result.amount).toBe(100);
+            expect(result.conditions).toBeDefined();
+            expect(result.conditions?.type).toBe('price_below');
+            expect(result.conditions?.value).toBe(2000);
+        }
+    });
+
+    it('should detect limit order intent with "rises above"', async () => {
+        const result = await parseUserCommand('Convert 1 ETH to USDC if price goes above 3000');
+        expect(result.success).toBe(true);
+        if ('intent' in result) {
+            expect(result.intent).toBe('limit_order');
+            expect(result.fromAsset).toBe('ETH');
+            expect(result.conditions?.type).toBe('price_above');
+            expect(result.conditions?.value).toBe(3000);
+        }
+    });
+
+    it('should detect "greater than"', async () => {
+        const result = await parseUserCommand('Swap ETH to USDC when price > 4000');
+        if ('intent' in result) {
+             expect(result.intent).toBe('limit_order');
+             expect(result.conditions?.type).toBe('price_above');
+             expect(result.conditions?.value).toBe(4000);
+        }
+    });
+});

--- a/bot/src/services/parseUserCommand.ts
+++ b/bot/src/services/parseUserCommand.ts
@@ -224,6 +224,7 @@ export async function parseUserCommand(
     // F. Detect Limit Order Condition
     const conditionMatch = input.match(REGEX_CONDITION);
     if (conditionMatch) {
+        intent = 'limit_order';
         const assetStr = conditionMatch[1];
         const operatorStr = conditionMatch[2].toLowerCase();
         const valueStr = conditionMatch[3];
@@ -238,10 +239,11 @@ export async function parseUserCommand(
             }
         }
 
-        if (['above', 'greater', 'more', 'rises', '>'].some(s => operatorStr.includes(s))) {
-            conditionOperator = 'gt';
-        } else {
+        // Logic fix: "drops below" -> lt, "rises above" -> gt
+        if (operatorStr.includes('below') || operatorStr.includes('less') || operatorStr.includes('under') || operatorStr.includes('<') || operatorStr.includes('drops') || operatorStr.includes('falls')) {
             conditionOperator = 'lt';
+        } else {
+            conditionOperator = 'gt';
         }
 
         if (conditionValue) {


### PR DESCRIPTION
### PR Description

**Title:** feat: Integrate Natural Language Limit Orders (#184)

**Description:**
This PR implements the ability for users to create limit orders using natural language commands, addressing issue #184.

**Changes:**
- **Enhanced `parseUserCommand`**: Updated regex patterns and logic to detect limit order intents such as "when price drops below 2000" or "if price rises above 3500". It now correctly extracts:
    - `conditionOperator`: `gt` (greater than) or `lt` (less than)
    - `conditionValue`: The target price
    - `conditionAsset`: The asset to monitor (defaults to `fromAsset` if not specified)
- **Bot Integration**: Updated `bot.ts` to handle the `limit_order` intent.
    - Displays a confirmation message with the swap details and condition.
    - Implemented `confirm_limit_order` action to save the order to the `limit_orders` database table.
- **Testing**: Added `bot/src/services/__tests__/limit-order-parsing.test.ts` to verify the parsing logic for various natural language phrases.
- **Worker Verification**: Validated that `limitOrderWorker.ts` is correctly implemented and instantiated to monitor prices and execute these orders.

**Example Commands:**
- "Swap 100 USDC to ETH when ETH drops below 2000"
- "Buy ETH if price rises above 3500"

**Related Issue:** 
closes #184