### PR TITLE
fix: replace exec() with execFile() to prevent shell injection in FFm…

### DIFF
--- a/bot/src/bot.ts
+++ b/bot/src/bot.ts
@@ -9,7 +9,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import axios from 'axios';
-import { spawn } from 'child_process';
+import { execFile } from 'child_process';
 import express from 'express';
 import { sql } from 'drizzle-orm';
 
@@ -148,7 +148,7 @@ bot.on(message('voice'), async (ctx) => {
     fs.writeFileSync(oga, res.data);
 
     await new Promise<void>((resolve, reject) =>
-      exec(`ffmpeg -i "${oga}" "${mp3}" -y`, (e) => (e ? reject(e) : resolve()))
+      execFile('ffmpeg', ['-i', oga, mp3, '-y'], (e) => (e ? reject(e) : resolve()))
     );
 
     const text = await transcribeAudio(mp3);


### PR DESCRIPTION
## Summary

Fixes #328 — Shell Injection in FFmpeg Audio Processing

Replaced `exec()` (shell-interpreted string interpolation) with `execFile()` (no shell, args as array) in the voice message handler.

## Changes

**[bot/src/bot.ts](cci:7://file:///d:/Open-Source-Projects/SwapSmith/bot/src/bot.ts:0:0-0:0)**

| Line | Before | After |
|------|--------|-------|
| 12 | `import { spawn }` | `import { execFile }` |
| 151 | `exec(\`ffmpeg -i "${oga}" "${mp3}" -y\`)` | `execFile('ffmpeg', ['-i', oga, mp3, '-y'], ...)` |

`execFile()` bypasses the shell entirely, so special characters in file paths can never be interpreted as commands.

## Testing

- TypeScript compilation verified — all errors are pre-existing on `main`
- E2E voice testing requires a live Telegram bot + FFmpeg

## Pre-existing Errors on `main`

| Error | Lines | Description |
|-------|-------|-------------|
| Duplicate imports | 4/18, 6/17, 7/34 | `logger`, `transcribeAudio`, `parseUserCommand` imported twice |
| Missing `@types` | 14, 36 | `drizzle-orm`, `@sentry/node` |
| Bracket mismatch | 251–253 | `}` instead of `)` in portfolio handler |
| Missing functions | 267, 305 | `createOrder`, `createCheckout` never imported |
| `parsed` out of scope | 343–374 | Referenced outside defining scope |