### PR TITLE
Fix the migration path and shared dependency intsalled

### DIFF
--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -10,16 +10,24 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Set the working directory in the container
-WORKDIR /usr/src/app
+WORKDIR /app
 
-# Copy package.json and package-lock.json
-COPY package*.json ./
+# Copy both folders
+COPY bot ./bot
+COPY shared ./shared
 
-# Install app dependencies
+# Install shared dependencies
+RUN npm install --prefix ./shared
+
+# Switch to bot folder
+WORKDIR /app/bot
+
+# Install bot dependencies
+COPY bot/package*.json ./
 RUN npm ci
 
-# Copy the rest of your app's source code
-COPY . .
+# Copy the rest of bot's source code
+COPY bot/ .
 
 # Run the build script to compile TypeScript to JavaScript
 RUN npm run build

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,15 +14,15 @@ services:
   
   bot:
     build:
-      context: ./bot
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: bot/Dockerfile
     container_name: swapsmith-bot
     restart: unless-stopped
     env_file:
       - ./bot/.env
     environment:
       - DATABASE_URL=postgres://postgres:postgres@db:5432/swapsmith
-    command: sh -c "npm run db:migrate && npm run start"
+    command: sh -c "npm run db:migrate --prefix /app/shared && npm run start"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Fixes Applied Successfully

### Changes Made

#### 1. docker-compose.yaml
- **Line 17-18**: Changed build context from `./bot` to `.` (root) to access both `bot/` and `shared/` folders
- **Line 25**: Migration command with absolute path for safety:
  ```yaml
  command: sh -c "npm run db:migrate --prefix /app/shared && npm run start"
  ```

#### 2. bot/Dockerfile (Complete rewrite with cleaner structure)
- **Line 13**: `WORKDIR /app` - base working directory
- **Line 16-17**: Copy both `bot` and `shared` folders into container
- **Line 20**: `RUN npm install --prefix ./shared` - install shared dependencies
- **Line 23**: `WORKDIR /app/bot` - switch to bot directory for npm install and build
- **Line 27**: `RUN npm ci` - install bot dependencies
- **Line 33**: `RUN npm run build` - compile TypeScript

### Container Structure
```
/app
├── bot/        # Bot application (WORKDIR at runtime)
└── shared/    # Shared schemas and migrations
```

### Verification Complete
- ✅ [`shared/package.json:9`](shared/package.json:9) contains `"db:migrate": "drizzle-kit migrate"`
- ✅ [`shared/drizzle.config.ts`](shared/drizzle.config.ts) exists with proper configuration
- ✅ Absolute path `/app/shared` used - no dependency on WORKDIR assumptions

### Issue 2 - No Changes Needed
[`bot/src/services/order-worker.ts:42`](bot/src/services/order-worker.ts:42) correctly calls `priceMonitor.checkPendingLimitOrders()` - the function exists with matching signature.

### To Test
```bash
docker-compose down
docker-compose build --no-cache
docker-compose up
```

Expected logs:
```
> drizzle-kit migrate
Applying migrations...
Migration completed successfully

> npm run start
Bot started successfully
```