### PR TITLE
fix: remove insecure JWT fallback that bypassed signature verificatio…

### DIFF
--- a/frontend/app/api/admin/verify/route.ts
+++ b/frontend/app/api/admin/verify/route.ts
@@ -16,22 +16,10 @@ export async function POST(req: NextRequest) {
     try {
       decoded = await adminAuth.verifyIdToken(idToken);
     } catch (verifyErr) {
-      // Firebase Admin SDK may not have a service account configured in local dev.
-      // Fall back to manually decoding the JWT payload (no signature verification).
-      // Security is maintained because admin status is checked against the DB row.
-      console.warn('[Admin Verify] verifyIdToken failed, falling back to JWT decode:', verifyErr);
-      try {
-        const parts = idToken.split('.');
-        if (parts.length !== 3) throw new Error('Malformed JWT');
-        const payload = JSON.parse(
-          Buffer.from(parts[1], 'base64url').toString('utf-8')
-        );
-        const uid = payload.user_id || payload.sub || payload.uid;
-        if (!uid) throw new Error('No uid in token payload');
-        decoded = { uid, email: payload.email };
-      } catch {
-        return NextResponse.json({ error: 'Invalid token.' }, { status: 401 });
-      }
+      // SECURITY: Never decode JWT without signature verification
+      // If Firebase Admin SDK fails, the token is invalid
+      console.error('[Admin Verify] Token verification failed:', verifyErr);
+      return NextResponse.json({ error: 'Invalid or expired token.' }, { status: 401 });
     }
 
     const admin = await getAdminByFirebaseUid(decoded.uid);


### PR DESCRIPTION
**Title:**
fix: Remove insecure JWT fallback that bypassed signature verification in admin auth


## Description
This PR fixes a critical security vulnerability (CVSS 9.8) in the admin verification endpoint that allowed attackers to bypass JWT signature verification and gain unauthorized admin access.

The vulnerability existed in `/api/admin/verify` where a fallback mechanism decoded JWT tokens without verifying their cryptographic signatures when Firebase Admin SDK verification failed.

## Related Issue
Closes #453 

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test addition/update

## Changes Made
- Removed insecure JWT decoding fallback in `frontend/app/api/admin/verify/route.ts` (lines 24-33)
- Replaced fallback with proper error handling that rejects unverified tokens
- All tokens now require valid Firebase Admin SDK signature verification
- Invalid tokens are now properly rejected with 401 Unauthorized status

**Security Impact:**
- **Before:** Attackers could forge JWT tokens and gain admin access
- **After:** Only cryptographically verified Firebase tokens are accepted

---

## Screenshots/Demo (if applicable)
N/A - Security fix with no UI changes

## Testing Done
- [x] Tested locally (npm run dev)
- [x] Production build successful (npm run build)
- [ ] All lint checks pass (npm run lint)
- [x] No TypeScript errors
- [ ] Tested in multiple browsers (Chrome, Firefox, Safari)
- [ ] Voice input tested (if applicable)
- [ ] Wallet connection tested (if applicable)

**Security Testing:**
- Verified forged JWT tokens are now rejected with 401 error
- Confirmed valid Firebase tokens still work correctly
- Tested error handling for malformed tokens

## Checklist
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [ ] Any dependent changes have been merged and published

## Additional Notes
**Severity:** CRITICAL (CVSS 9.8)

**Vulnerability Details:**
- The original code had a fallback that decoded JWT payloads without signature verification
- Attackers could create forged tokens with any `uid` value
- This allowed complete admin panel compromise

**Fix:**
- Removed the insecure fallback mechanism entirely
- All authentication now requires proper Firebase Admin SDK verification
- Failed verifications return 401 Unauthorized immediately
