### PR TITLE
fixed bot-container issue

### DIFF
--- a/bot/scripts/wait-for-db-and-migrate.sh
+++ b/bot/scripts/wait-for-db-and-migrate.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+set -e
+
+MAX_RETRIES="${MAX_RETRIES:-30}"
+SLEEP_SECONDS="${SLEEP_SECONDS:-2}"
+
+if [ -z "$DATABASE_URL" ]; then
+  echo "DATABASE_URL is not set; cannot wait for database"
+else
+  echo "Waiting for database at $DATABASE_URL..."
+  COUNTER=0
+  until pg_isready -d "$DATABASE_URL"; do
+    COUNTER=$((COUNTER + 1))
+    if [ "$COUNTER" -ge "$MAX_RETRIES" ]; then
+      echo "Database not ready after $MAX_RETRIES attempts, exiting"
+      exit 1
+    fi
+    echo "Database not ready yet (attempt $COUNTER/$MAX_RETRIES), retrying in ${SLEEP_SECONDS}s..."
+    sleep "$SLEEP_SECONDS"
+  done
+fi
+
+echo "Database is ready, running migrations..."
+npm run db:migrate
+
+echo "Migrations complete, starting bot..."
+npm run start:render
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
       - ./bot/.env
     environment:
       - DATABASE_URL=postgres://postgres:postgres@db:5432/swapsmith
-    command: sh -c "MAX_RETRIES=30; COUNTER=0; until pg_isready -d \"$DATABASE_URL\"; do COUNTER=$$((COUNTER+1)); if [ \"$$COUNTER\" -ge \"$$MAX_RETRIES\" ]; then echo \"Database not ready after $$MAX_RETRIES attempts, exiting\"; exit 1; fi; echo waiting for database; sleep 2; done; npm run db:migrate && npm run start"
+    command: sh -c "chmod +x ./scripts/wait-for-db-and-migrate.sh && ./scripts/wait-for-db-and-migrate.sh"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Description
Ensure the bot container only runs database migrations after Postgres is fully ready by introducing a dedicated pg_isready wait script and wiring it into docker-compose.

## Related Issue

Closes #445 

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test addition/update

## Changes Made

-Added bot/scripts/wait-for-db-and-migrate.sh to wait for Postgres using pg_isready, then run npm run db:migrate and start the bot.
-Updated the bot service in docker-compose.yaml to use the new script as its startup command instead of an inline shell one-liner.
-Ensured the flow respects DATABASE_URL and retry/timeout limits so the container fails fast if the DB never becomes reachable.

