### PR TITLE
Security: Add CSRF Protection to Create Checkout API Endpoint

### DIFF
--- a/frontend/pages/api/create-checkout.ts
+++ b/frontend/pages/api/create-checkout.ts
@@ -1,10 +1,16 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { createCheckout } from '@/utils/sideshift-client';
+import { csrfGuard } from '@/lib/csrf';
 
 const SIDESHIFT_CLIENT_IP = process.env.SIDESHIFT_CLIENT_IP || "127.0.0.1";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).end();
+  
+  // CSRF Protection - Critical for financial operations
+  if (!csrfGuard(req, res)) {
+    return;
+  }
   
   // ✅ Added settleAddress to destructuring
   const { settleAsset, settleNetwork, settleAmount, settleAddress } = req.body;


### PR DESCRIPTION
Implement CSRF token validation for the create-checkout API endpoint using Origin/Referer header validation:
- Add csrfGuard import and validation to create-checkout handler
- Protect against Cross-Site Request Forgery attacks on financial operations
- Validates requests originate from allowed origins
- Consistent with CSRF protection pattern across all financial API routes
- Now all state-modifying API endpoints have proper security validation

Resolves #444: Missing CSRF Protection