### PR TITLE
fix(#465): make ads container and modal mobile responsive

### DIFF
--- a/frontend/components/AdsContainer.tsx
+++ b/frontend/components/AdsContainer.tsx
@@ -210,16 +210,16 @@ export default function AdsContainer({
   if (!visible || !resolvedAd) return null
 
   const positionClasses = {
-    'bottom-right': 'bottom-6 right-6',
-    'bottom-left': 'bottom-6 left-6',
-    'bottom-center': 'bottom-6 left-1/2 -translate-x-1/2',
+    'bottom-right': 'bottom-3 right-3 sm:bottom-6 sm:right-6',
+    'bottom-left': 'bottom-3 left-3 sm:bottom-6 sm:left-6',
+    'bottom-center': 'bottom-3 left-1/2 -translate-x-1/2 sm:bottom-6',
   }[position]
 
   const currentAd = resolvedAd
 
   return (
     <div
-      className={`fixed ${positionClasses} z-[9999] w-80 max-w-[calc(100vw-3rem)] animate-in fade-in slide-in-from-bottom-4 duration-300`}
+      className={`fixed ${positionClasses} z-[9999] w-72 sm:w-80 max-w-[calc(100vw-1.5rem)] animate-in fade-in slide-in-from-bottom-4 duration-300`}
       role="complementary"
       aria-label="Advertisement"
     >

--- a/frontend/components/FullPageAd.tsx
+++ b/frontend/components/FullPageAd.tsx
@@ -184,10 +184,10 @@ export default function FullPageAd({
 
   return (
     <div
-      className="fixed inset-0 z-[9999] flex items-center justify-center p-4"
+      className="fixed inset-0 z-[9999] flex items-center justify-center p-2 sm:p-4"
       style={{ background: 'rgba(15,23,42,0.80)', backdropFilter: 'blur(10px)', WebkitBackdropFilter: 'blur(10px)' }}
     >
-      <div className="relative w-full max-w-5xl bg-white rounded-2xl shadow-2xl overflow-hidden">
+      <div className="relative w-full max-w-5xl max-h-[90vh] overflow-x-hidden overflow-y-auto bg-white rounded-2xl shadow-2xl">
 
         {/* Dismiss */}
         <button
@@ -206,24 +206,24 @@ export default function FullPageAd({
 
         {/* PLANS VARIANT */}
         {variant === 'plans' && (
-          <div className="px-8 pt-10 pb-8">
+          <div className="px-4 pt-8 pb-5 sm:px-8 sm:pt-10 sm:pb-8">
             <span className="absolute top-10 left-10 text-2xl select-none pointer-events-none"></span>
             <span className="absolute top-8 right-20 text-xl select-none pointer-events-none"></span>
 
-            <div className="text-center mb-7">
+            <div className="text-center mb-4 sm:mb-7">
               <p className="text-sm font-bold text-blue-500 mb-2 tracking-wide">Simple Pricing</p>
-              <h2 className="text-3xl font-black text-gray-900 tracking-tight mb-2">
+              <h2 className="text-xl sm:text-3xl font-black text-gray-900 tracking-tight mb-2">
                 Unlock <span className="text-blue-600">SwapSmith&apos;s</span> full potential
               </h2>
               <p className="text-sm text-gray-500">AI routing  Telegram swaps  yield scouting — pick your plan.</p>
             </div>
 
-            <div className="grid grid-cols-3 gap-4 items-start">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 items-start">
               {PLANS.map((plan, i) => (
                 <div
                   key={plan.name}
-                  className={`ad-card-enter ad-card-hover relative flex flex-col rounded-2xl p-5 border ${plan.popular ? 'border-gray-800 shadow-xl' : 'border-gray-200'}`}
-                  style={plan.popular ? { transform: 'translateY(-6px) scale(1.02)', animationDelay: `${i * 0.12}s` } : { animationDelay: `${i * 0.12}s` }}
+                  className={`ad-card-enter ad-card-hover relative flex flex-col rounded-2xl p-4 sm:p-5 border ${plan.popular ? 'border-gray-800 shadow-xl sm:-translate-y-1.5 sm:scale-[1.02] mt-6 sm:mt-0' : 'border-gray-200'}`}
+                  style={{ animationDelay: `${i * 0.12}s` }}
                 >
                   {plan.popular && (
                     <div className="absolute -top-3.5 left-1/2 -translate-x-1/2 px-4 py-1 rounded-full text-xs font-black text-white whitespace-nowrap" style={{ background: '#f59e0b' }}>
@@ -236,7 +236,7 @@ export default function FullPageAd({
                   <h3 className="text-base font-black text-gray-900 mb-0.5">{plan.name}</h3>
                   <p className="text-[11px] text-gray-500 mb-3 leading-snug">{plan.tagline}</p>
                   <div className="flex items-baseline gap-1 mb-4">
-                    <span className="text-3xl font-black text-gray-900">{plan.price}</span>
+                    <span className="text-2xl sm:text-3xl font-black text-gray-900">{plan.price}</span>
                     <span className="text-sm text-gray-400">{plan.period}</span>
                   </div>
                   <ul className="flex flex-col gap-2 flex-1 mb-5">
@@ -265,24 +265,24 @@ export default function FullPageAd({
 
         {/* FEATURES VARIANT */}
         {variant === 'features' && (
-          <div className="px-8 pt-10 pb-8">
+          <div className="px-4 pt-8 pb-5 sm:px-8 sm:pt-10 sm:pb-8">
             <span className="absolute top-10 left-10 text-2xl select-none pointer-events-none"></span>
             <span className="absolute top-8 right-20 text-xl select-none pointer-events-none"></span>
 
-            <div className="text-center mb-7">
+            <div className="text-center mb-4 sm:mb-7">
               <p className="text-sm font-bold text-blue-500 mb-2 tracking-wide">Explore SwapSmith</p>
-              <h2 className="text-3xl font-black text-gray-900 tracking-tight mb-2">
+              <h2 className="text-xl sm:text-3xl font-black text-gray-900 tracking-tight mb-2">
                 Powerful tools, <span className="text-blue-600">built for DeFi</span>
               </h2>
               <p className="text-sm text-gray-500">Trade smarter with SwapSmith&apos;s suite of decentralised finance tools.</p>
             </div>
 
-            <div className="grid grid-cols-3 gap-4 items-start">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 items-start">
               {SITE_FEATURES.map((feat, i) => (
                 <div
                   key={feat.name}
-                  className={`ad-card-enter ad-card-hover relative flex flex-col rounded-2xl p-5 border ${feat.popular ? 'border-gray-800 shadow-xl' : 'border-gray-200'}`}
-                  style={feat.popular ? { transform: 'translateY(-6px) scale(1.02)', animationDelay: `${i * 0.12}s` } : { animationDelay: `${i * 0.12}s` }}
+                  className={`ad-card-enter ad-card-hover relative flex flex-col rounded-2xl p-4 sm:p-5 border ${feat.popular ? 'border-gray-800 shadow-xl sm:-translate-y-1.5 sm:scale-[1.02] mt-6 sm:mt-0' : 'border-gray-200'}`}
+                  style={{ animationDelay: `${i * 0.12}s` }}
                 >
                   {feat.popular && (
                     <div className="absolute -top-3.5 left-1/2 -translate-x-1/2 px-4 py-1 rounded-full text-xs font-black text-white whitespace-nowrap" style={{ background: '#f59e0b' }}>
@@ -295,7 +295,7 @@ export default function FullPageAd({
                   <h3 className="text-base font-black text-gray-900 mb-0.5">{feat.name}</h3>
                   <p className="text-[11px] text-gray-500 mb-3 leading-snug">{feat.tagline}</p>
                   <div className="flex items-baseline gap-1 mb-4">
-                    <span className="text-3xl font-black text-gray-900">{feat.statNum}</span>
+                    <span className="text-2xl sm:text-3xl font-black text-gray-900">{feat.statNum}</span>
                     <span className="text-sm text-gray-400">{feat.statLabel}</span>
                   </div>
                   <ul className="flex flex-col gap-2 flex-1 mb-5">
@@ -326,26 +326,26 @@ export default function FullPageAd({
 
         {/* PROMO VARIANT */}
         {variant === 'promo' && (
-          <div className="px-8 pt-10 pb-8">
+          <div className="px-4 pt-8 pb-5 sm:px-8 sm:pt-10 sm:pb-8">
             <span className="absolute top-10 left-10 text-2xl select-none pointer-events-none">🎁</span>
             <span className="absolute top-8 right-20 text-xl select-none pointer-events-none">✨</span>
 
-            <div className="text-center mb-7">
+            <div className="text-center mb-4 sm:mb-7">
               <p className="text-sm font-bold text-blue-500 mb-2 tracking-wide">Discover SwapSmith</p>
-              <h2 className="text-3xl font-black text-gray-900 tracking-tight mb-2">
+              <h2 className="text-xl sm:text-3xl font-black text-gray-900 tracking-tight mb-2">
                 More ways to <span className="text-blue-600">earn &amp; learn</span>
               </h2>
               <p className="text-sm text-gray-500">Connect your wallet, level up your DeFi knowledge, and earn rewards every day.</p>
             </div>
 
-            <div className="grid grid-cols-3 gap-4 items-start">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 items-start">
               {PROMO_CARDS.map((card, i) => (
                 <div
                   key={card.name}
-                  className={`ad-card-enter ad-card-hover relative flex flex-col rounded-2xl p-5 border ${
-                    card.popular ? 'border-gray-800 shadow-xl' : 'border-gray-200'
+                  className={`ad-card-enter ad-card-hover relative flex flex-col rounded-2xl p-4 sm:p-5 border ${
+                    card.popular ? 'border-gray-800 shadow-xl sm:-translate-y-1.5 sm:scale-[1.02] mt-6 sm:mt-0' : 'border-gray-200'
                   }`}
-                  style={card.popular ? { transform: 'translateY(-6px) scale(1.02)', animationDelay: `${i * 0.12}s` } : { animationDelay: `${i * 0.12}s` }}
+                  style={{ animationDelay: `${i * 0.12}s` }}
                 >
                   {card.popular && (
                     <div className="absolute -top-3.5 left-1/2 -translate-x-1/2 px-4 py-1 rounded-full text-xs font-black text-white whitespace-nowrap" style={{ background: '#f59e0b' }}>
@@ -358,7 +358,7 @@ export default function FullPageAd({
                   <h3 className="text-base font-black text-gray-900 mb-0.5">{card.name}</h3>
                   <p className="text-[11px] text-gray-500 mb-3 leading-snug">{card.tagline}</p>
                   <div className="flex items-baseline gap-1 mb-4">
-                    <span className="text-3xl font-black text-gray-900">{card.statNum}</span>
+                    <span className="text-2xl sm:text-3xl font-black text-gray-900">{card.statNum}</span>
                     <span className="text-sm text-gray-400">{card.statLabel}</span>
                   </div>
                   <ul className="flex flex-col gap-2 flex-1 mb-5">

--- a/frontend/public/ad-preview.js
+++ b/frontend/public/ad-preview.js
@@ -130,16 +130,26 @@
     overlay.id = '__swapsmith_ad_preview__'
     overlay.style.cssText = `
       position:fixed; inset:0; z-index:99999;
-      display:flex; align-items:center; justify-content:center; padding:16px;
+      display:flex; align-items:center; justify-content:center; padding:8px;
       background:rgba(15,23,42,0.82);
       backdrop-filter:blur(10px); -webkit-backdrop-filter:blur(10px);
     `
 
     overlay.innerHTML = `
-      <div style="
+      <style>
+        @media (max-width: 600px) {
+          #__ss_ad_inner__ { border-radius: 14px !important; }
+          #__ss_ad_body__ { padding: 40px 16px 20px !important; }
+          #__ss_ad_grid__ { grid-template-columns: 1fr !important; }
+          #__ss_ad_heading__ { font-size: 20px !important; line-height: 1.25 !important; }
+          #__ss_ad_dismiss__ { top: 10px !important; right: 10px !important; }
+        }
+      </style>
+      <div id="__ss_ad_inner__" style="
         position:relative; width:100%; max-width:768px;
+        max-height:90vh; overflow-x:hidden; overflow-y:auto;
         background:#fff; border-radius:20px;
-        box-shadow:0 25px 80px rgba(0,0,0,0.35); overflow:hidden;
+        box-shadow:0 25px 80px rgba(0,0,0,0.35);
       ">
         <!-- Dismiss -->
         <button id="__ss_ad_dismiss__" style="
@@ -157,16 +167,16 @@
         <span style="position:absolute;top:42px;left:42px;font-size:22px;pointer-events:none;user-select:none;">⭐</span>
         <span style="position:absolute;top:36px;right:80px;font-size:18px;pointer-events:none;user-select:none;">✨</span>
 
-        <div style="padding:40px 32px 32px;">
+        <div id="__ss_ad_body__" style="padding:40px 32px 32px;">
           <!-- Header -->
           <div style="text-align:center; margin-bottom:28px;">
             <p style="font-size:13px; font-weight:700; color:#2563eb; margin:0 0 6px; letter-spacing:0.03em;">${data.eyebrow}</p>
-            <h2 style="font-size:26px; font-weight:900; color:#111; margin:0 0 6px; letter-spacing:-0.03em; line-height:1.2;">${data.title}</h2>
+            <h2 id="__ss_ad_heading__" style="font-size:26px; font-weight:900; color:#111; margin:0 0 6px; letter-spacing:-0.03em; line-height:1.2;">${data.title}</h2>
             <p style="font-size:13px; color:#6b7280; margin:0;">${data.subtitle}</p>
           </div>
 
           <!-- Cards -->
-          <div style="display:grid; grid-template-columns:repeat(3,1fr); gap:16px; align-items:start;">
+          <div id="__ss_ad_grid__" style="display:grid; grid-template-columns:repeat(3,1fr); gap:16px; align-items:start;">
             ${cardHTML}
           </div>
         </div>


### PR DESCRIPTION
PR: fix(#465) - Adjust Ads Container Size for Mobile Screens
Branch: fix/mobile-responsive-ads-container
Closes: #465
<img width="473" height="872" alt="adds" src="https://github.com/user-attachments/assets/2c05957d-d2c1-4ca5-84ce-b86c7934bfb0" />

=== FILES CHANGED ===

1. frontend/components/FullPageAd.tsx
   - Outer overlay padding: p-2 sm:p-4 (was p-4 only)
   - White modal panel: added max-h-[90vh] overflow-x-hidden overflow-y-auto
     so content is scrollable on very small screens instead of overflowing
   - All 3 variants (plans / features / promo):
       - Inner padding: px-4 pt-8 pb-5 sm:px-8 sm:pt-10 sm:pb-8
       - Section heading spacing: mb-4 sm:mb-7
       - Section headings: text-xl sm:text-3xl (readable on mobile)
       - Price / stat numbers: text-2xl sm:text-3xl
       - Card grid: grid-cols-1 sm:grid-cols-3
         (single column on mobile, 3 columns on tablet+)
       - Card padding: p-4 sm:p-5
       - Popular card lift/scale: sm:-translate-y-1.5 sm:scale-[1.02]
         (lift effect only on tablet+, no overflow on mobile)
       - Popular card top spacing: mt-6 sm:mt-0
         (prevents "Popular!" badge from being clipped in single-column layout)

2. frontend/components/AdsContainer.tsx
   - Float card width: w-72 sm:w-80 (slightly narrower on mobile)
   - Max-width: max-w-[calc(100vw-1.5rem)] (was 3rem, tighter on mobile)
   - Edge offsets for all positions:
       bottom-right: bottom-3 right-3 sm:bottom-6 sm:right-6
       bottom-left:  bottom-3 left-3  sm:bottom-6 sm:left-6
       bottom-center: bottom-3 sm:bottom-6
     (card sits closer to screen edges on mobile to avoid overflow)

3. frontend/public/ad-preview.js  (DevTools preview script)
   - Overlay padding reduced to 8px (from 16px) for smaller screens
   - Inner panel: max-height:90vh; overflow-y:auto; overflow-x:hidden
   - Added <style> block with @media (max-width: 600px) rules:
       #__ss_ad_grid__   grid-template-columns: 1fr (single column)
       #__ss_ad_body__   padding: 40px 16px 20px
       #__ss_ad_heading__ font-size: 20px; line-height: 1.25
       #__ss_ad_inner__  border-radius: 14px
       #__ss_ad_dismiss__ repositioned to top:10px right:10px
   - Added IDs to inner wrapper, body, grid, and heading divs
     so the media query rules can target them precisely

=== VERIFICATION ===
- npm run lint  : 0 errors (1 pre-existing unrelated warning)
- npm run build : Compiled successfully, all 69 pages generated
