### PR TITLE
Add natural language support for Limit Orders and DCA

### DIFF
--- a/bot/src/services/nl-dca.ts
+++ b/bot/src/services/nl-dca.ts
@@ -1,0 +1,159 @@
+/**
+ * Natural Language Parser for Dollar Cost Averaging (DCA)
+ * Handles phrases like:
+ * - "Invest $100 in Bitcoin daily"
+ * - "Buy $50 of ETH every week"
+ * - "DCA 0.5 BTC monthly"
+ * - "Swap $200 to USDC bi-weekly"
+ */
+
+export interface DCAScheduleNLConfig {
+  asset: string;
+  targetAsset: string;
+  amount: number;
+  amountType: 'exact' | 'percentage';
+  frequency: 'daily' | 'weekly' | 'bi-weekly' | 'monthly' | 'quarterly';
+  dayOfWeek?: number; // 0-6 (Sunday-Saturday)
+  dayOfMonth?: number; // 1-28
+}
+
+const DCA_PATTERNS = [
+  // "$X per/every [period]"
+  /\$(\d+(?:\.\d+)?)\s+(?:per|every|each)\s+(day|week|bi-?week|month|quarter|daily|weekly|monthly|quarterly)/i,
+  
+  // "invest/buy $X [asset] every/daily/weekly/monthly"
+  /(?:invest|buy|swap|convert|dca)\s+\$(\d+(?:\.\d+)?)\s+(?:in|of|into)?\s+([A-Z]{2,10})?\s+(?:every|per|each|daily|weekly|bi-?weekly|monthly|quarterly|each\s+)?(\w+)?/i,
+  
+  // "buy X tokens every Y"
+  /(?:invest|buy|swap|convert|dca)\s+([0-9.]+)\s+([A-Z]{2,10})\s+(?:every|per|each|daily|weekly|bi-?weekly|monthly|quarterly|each\s+)?(\w+)?/i,
+  
+  // "DCA into [asset] - $X [period]"
+  /dca\s+(?:into|into|in)\s+([A-Z]{2,10})\s+[-–:]\s*\$(\d+(?:\.\d+)?)\s+(?:per|every)?\s*(\w+)/i,
+  
+  // "set up recurring buy of $X daily/weekly"
+  /(?:recurring|scheduled|set\s+up)\s+(?:buy|investment|dca)\s+(?:of)?s*\$(\d+(?:\.\d+)?)\s+(?:every\s+)?(\w+)/i,
+];
+
+const FREQUENCY_MAP: Record<string, DCAScheduleNLConfig['frequency']> = {
+  'day': 'daily',
+  'daily': 'daily',
+  'week': 'weekly',
+  'weekly': 'weekly',
+  'bi-week': 'bi-weekly',
+  'biweek': 'bi-weekly',
+  'month': 'monthly',
+  'monthly': 'monthly',
+  'quarter': 'quarterly',
+  'quarterly': 'quarterly',
+};
+
+const DAY_OF_WEEK_MAP: Record<string, number> = {
+  'monday': 1,
+  'tuesday': 2,
+  'wednesday': 3,
+  'thursday': 4,
+  'friday': 5,
+  'saturday': 6,
+  'sunday': 0,
+};
+
+function parseFrequency(freqStr: string): DCAScheduleNLConfig['frequency'] | null {
+  const normalized = freqStr.toLowerCase().replace(/s$/, '');
+  return FREQUENCY_MAP[normalized] || null;
+}
+
+function extractDayOfWeek(input: string): number | undefined {
+  const match = input.match(/(?:every|each|on|each)\s+(\w+day|monday|tuesday|wednesday|thursday|friday|saturday|sunday)/i);
+  if (match) {
+    return DAY_OF_WEEK_MAP[match[1].toLowerCase()];
+  }
+  return undefined;
+}
+
+function extractDayOfMonth(input: string): number | undefined {
+  const match = input.match(/(?:on\s+the\s+)?(\d{1,2})(?:st|nd|rd|th)?(?:\s+of)?/i);
+  if (match) {
+    const day = parseInt(match[1]);
+    return day >= 1 && day <= 28 ? day : undefined;
+  }
+  return undefined;
+}
+
+export function detectDCA(input: string): Partial<DCAScheduleNLConfig> | null {
+  // Quick check for DCA keywords
+  const hasDCAKeyword = /\b(dca|recurring|scheduled|every|daily|weekly|bi-?weekly|monthly|quarterly)\b/i.test(input);
+  if (!hasDCAKeyword) return null;
+
+  for (const pattern of DCA_PATTERNS) {
+    const match = input.match(pattern);
+    if (!match) continue;
+
+    const config: Partial<DCAScheduleNLConfig> = {
+      amountType: 'exact',
+    };
+
+    // Extract amount ($X or X tokens)
+    let amount: number | null = null;
+    let asset: string | null = null;
+    let targetAsset: string | null = null;
+
+    if (match[1]) {
+      amount = parseFloat(match[1]);
+    }
+
+    // Extract assets
+    if (match[2]) {
+      const extracted = match[2].toUpperCase();
+      if (extracted && !/\b(per|every|each|daily|weekly|monthly|quarterly)\b/i.test(extracted)) {
+        asset = extracted;
+      }
+    }
+
+    if (match[3]) {
+      const freq = parseFrequency(match[3]);
+      if (freq) {
+        config.frequency = freq;
+      } else if (/[A-Z]{2,10}/.test(match[3])) {
+        targetAsset = match[3].toUpperCase();
+      }
+    }
+
+    // Fallback: extract assets from input
+    if (!asset) {
+      const assetMatch = input.match(/(?:buy|invest|swap|convert|into|in|of)\s+([A-Z]{2,10})/i);
+      if (assetMatch) {
+        asset = assetMatch[1].toUpperCase();
+      }
+    }
+
+    if (!targetAsset) {
+      const targetMatch = input.match(/(?:to|into|for|in)\s+([A-Z]{2,10})/i);
+      if (targetMatch && targetMatch[1] !== asset) {
+        targetAsset = targetMatch[1].toUpperCase();
+      }
+    }
+
+    // Parse frequency if not already done
+    if (!config.frequency) {
+      const freqMatch = input.match(/(?:daily|weekly|bi-?weekly|monthly|quarterly|every\s+(\w+))/i);
+      if (freqMatch) {
+        const freq = parseFrequency(freqMatch[1] || freqMatch[0]);
+        if (freq) config.frequency = freq;
+      }
+    }
+
+    // Extract day information
+    config.dayOfWeek = extractDayOfWeek(input);
+    config.dayOfMonth = extractDayOfMonth(input);
+
+    // Build final config
+    if (amount && (asset || targetAsset) && config.frequency) {
+      config.amount = amount;
+      config.asset = asset || 'USDC';
+      config.targetAsset = targetAsset || 'USDC';
+      return config;
+    }
+  }
+
+  return null;
+}

--- a/bot/src/services/nl-limit-orders.ts
+++ b/bot/src/services/nl-limit-orders.ts
@@ -1,0 +1,89 @@
+/**
+ * Natural Language Parser for Limit Orders
+ * Handles phrases like:
+ * - "Buy ETH if price drops below $2000"
+ * - "Sell when BTC hits $50k"
+ * - "Convert to USDC when ETH goes above $3000"
+ */
+
+export interface LimitOrderNLConfig {
+  asset: string;
+  targetAsset?: string;
+  price: number;
+  condition: 'above' | 'below';
+  amount?: number;
+  amountType?: 'exact' | 'percentage';
+}
+
+const LIMIT_ORDER_PATTERNS = [
+  // "buy/sell X when/if price [goes] above/below $Y"
+  /\b(buy|sell|convert|swap)\s+([A-Z]{2,10})?\s+(?:when|if)?\s+(?:price\s+)?(?:goes?\s+)?(above|below|drops?|rises?|>|<|hits?)\s*\$?(\d+(?:\.\d+)?[km]?)/i,
+  
+  // "when BTC drops below $40k, sell my ETH"
+  /when\s+([A-Z]{2,10})\s+(drops?\s+below|goes?\s+below|hits?\s+below|<)\s*\$?(\d+(?:\.\d+)?[km]?)/i,
+  
+  // "sell all if ETH above $3000"
+  /(?:sell|buy|convert)\s+(?:all|my)?\s+([A-Z]{2,10})?\s+(?:if|when)\s+([A-Z]{2,10})?\s+(?:is|price)?\s+(above|below|>|<)\s*\$?(\d+(?:\.\d+)?[km]?)/i,
+  
+  // "execute when price reaches $X"
+  /(?:execute|trigger|go|convert)\s+(?:when|if)?\s+(?:price\s+)?(?:reaches?|hits?)\s*\$?(\d+(?:\.\d+)?[km]?)/i,
+];
+
+const SCALING_SUFFIXES = { k: 1000, m: 1_000_000 };
+
+function parseScaledPrice(rawPrice: string): number {
+  const cleaned = rawPrice.toLowerCase().replace(/[^\d.km]/g, '');
+  const base = parseFloat(cleaned);
+  if (isNaN(base)) return NaN;
+  
+  const suffix = cleaned.slice(-1) as keyof typeof SCALING_SUFFIXES;
+  return SCALING_SUFFIXES[suffix] ? base * SCALING_SUFFIXES[suffix] : base;
+}
+
+export function detectLimitOrder(input: string): Partial<LimitOrderNLConfig> | null {
+  for (const pattern of LIMIT_ORDER_PATTERNS) {
+    const match = input.match(pattern);
+    if (!match) continue;
+
+    const config: Partial<LimitOrderNLConfig> = {};
+
+    // Extract action and assets
+    const action = match[1]?.toLowerCase();
+    const asset = match[2]?.toUpperCase();
+    const conditionWord = match[3] || match[5] || match[6];
+    const priceStr = match[4] || match[7];
+
+    if (!priceStr) continue;
+
+    config.price = parseScaledPrice(priceStr);
+    if (isNaN(config.price)) continue;
+
+    // Determine condition type
+    if (/(above|>|rises?|hits?)/i.test(conditionWord)) {
+      config.condition = 'above';
+    } else if (/(below|<|drops?)/i.test(conditionWord)) {
+      config.condition = 'below';
+    } else {
+      continue;
+    }
+
+    // Set asset
+    if (asset && !['PRICE', 'IF', 'WHEN'].includes(asset)) {
+      config.asset = asset;
+      
+      // For "sell/buy X when Y above $Z", X is the asset to trade
+      if (/\b(sell|buy|convert|swap)\b/i.test(input) && action) {
+        const assetAfterAction = input.match(new RegExp(`\\b${action}\\s+([A-Z]{2,10})`, 'i'));
+        if (assetAfterAction) {
+          config.asset = assetAfterAction[1].toUpperCase();
+        }
+      }
+    }
+
+    if (config.asset && config.condition && config.price) {
+      return config;
+    }
+  }
+
+  return null;
+}

--- a/bot/src/services/parseUserCommand.ts
+++ b/bot/src/services/parseUserCommand.ts
@@ -1,4 +1,6 @@
 import { parseWithLLM, ParsedCommand } from './groq-client';
+import { detectLimitOrder } from './nl-limit-orders';
+import { detectDCA } from './nl-dca';
 import logger from './logger';
 
 export { ParsedCommand };
@@ -142,6 +144,44 @@ export async function parseUserCommand(
       fromProject: stakeProtocol,
       toProject: stakeProtocol,
       parsedMessage: `Parsed: Swap ${amount ?? '?'} ${fromAsset ?? '?'} → ${toAsset ?? 'USDC'} and stake`
+    };
+  }
+
+  /* ───────────── NATURAL LANGUAGE LIMIT ORDERS ───────────── */
+  const limitOrderNL = detectLimitOrder(input);
+  if (limitOrderNL && limitOrderNL.asset && limitOrderNL.price !== undefined && limitOrderNL.condition) {
+    return buildSwapResult(userInput, {
+      intent: 'limit_order',
+      fromAsset: limitOrderNL.asset,
+      toAsset: limitOrderNL.targetAsset ?? 'USDC',
+      amount: limitOrderNL.amount ?? null,
+      amountType: limitOrderNL.amountType ?? 'all',
+      condition: limitOrderNL.condition,
+      conditionValue: limitOrderNL.price,
+      conditionAsset: limitOrderNL.asset,
+      conditionOperator: limitOrderNL.condition === 'above' ? 'gt' : 'lt',
+      confidence: 85,
+      requiresConfirmation: true
+    });
+  }
+
+  /* ───────────── NATURAL LANGUAGE DCA ───────────── */
+  const dcaNL = detectDCA(input);
+  if (dcaNL && dcaNL.asset && dcaNL.targetAsset && dcaNL.amount !== undefined && dcaNL.frequency) {
+    return {
+      ...buildSwapResult(userInput, {
+        intent: 'dca',
+        fromAsset: dcaNL.asset,
+        toAsset: dcaNL.targetAsset,
+        amount: dcaNL.amount,
+        amountType: dcaNL.amountType ?? 'exact',
+        frequency: dcaNL.frequency,
+        dayOfWeek: dcaNL.dayOfWeek,
+        dayOfMonth: dcaNL.dayOfMonth,
+        confidence: 85,
+        requiresConfirmation: true
+      }),
+      parsedMessage: `Parsed: DCA ${dcaNL.amount} ${dcaNL.asset} → ${dcaNL.targetAsset} ${dcaNL.frequency}`
     };
   }
 


### PR DESCRIPTION
This PR adds natural language parsing for Limit Orders and Dollar Cost Averaging (DCA) orders, enabling more conversational command input.


### New Services:

1.nl-limit-orders.ts - Detects limit order commands like "buy ETH if price drops below $2000" with support for scaled prices (k, m suffixes)
2.bot/src/services/nl-dca.ts - Detects DCA commands like "invest $100 in Bitcoin daily" with frequency parsing (daily/weekly/monthly/quarterly)


### Integration:

1.Updated parseUserCommand.ts to use NL detection before standard regex fallback (85% confidence)
2.Supports natural English phrasings without requiring specific syntax

closes: #536 


@GauravKarakoti  plz review it 