### PR TITLE
Fix wrong swap destination by ensuring depositAddress is validated

### DIFF
--- a/bot/src/services/sideshift-client.ts
+++ b/bot/src/services/sideshift-client.ts
@@ -22,6 +22,7 @@ export interface SideShiftQuote {
   id: string;
   depositCoin: string;
   depositNetwork: string;
+  depositAddress: string; // Address where user should send their deposit
   settleCoin: string;
   settleNetwork: string;
   depositAmount: string;
@@ -164,6 +165,7 @@ const SideShiftQuoteSchema = z.object({
   id: z.string(),
   depositCoin: z.string(),
   depositNetwork: z.string(),
+  depositAddress: z.string(), // Critical: Destination address for user's deposit
   settleCoin: z.string(),
   settleNetwork: z.string(),
   depositAmount: z.string(),


### PR DESCRIPTION
### description:
- Add missing depositAddress field to SideShiftQuote interface (bot service)
- Add depositAddress to SideShiftQuoteSchema for proper response validation
- Ensures swap transactions always send funds to SideShift deposit address
- Aligns with frontend implementation that already validates depositAddress
- Prevents accidental self-transfers that would waste gas
- depositAddress is now explicitly part of quote data validation flow

closes: #524 


@GauravKarakoti  plz review it 