### PR TITLE
fix: Add null safety checks for string split operations 

### DIFF
--- a/frontend/hooks/useCsrfToken.ts
+++ b/frontend/hooks/useCsrfToken.ts
@@ -13,8 +13,11 @@ export function useCsrfToken() {
     const csrfCookie = cookies.find(c => c.trim().startsWith('csrf-token='));
     
     if (csrfCookie) {
-      const tokenValue = csrfCookie.split('=')[1];
-      setToken(tokenValue);
+      const tokenParts = csrfCookie.split('=');
+      const tokenValue = tokenParts[1];
+      if (tokenValue && tokenValue.trim().length > 0) {
+        setToken(tokenValue.trim());
+      }
     }
   }, []);
 
@@ -45,7 +48,11 @@ export async function csrfFetch(
   const cookies = document.cookie.split(';');
   const csrfCookie = cookies.find(c => c.trim().startsWith('csrf-token='));
   
-  const token = csrfCookie?.split('=')[1];
+  let token: string | undefined;
+  if (csrfCookie) {
+    const tokenParts = csrfCookie.split('=');
+    token = tokenParts[1]?.trim();
+  }
 
   const headers = new Headers(options.headers || {});
 
@@ -87,8 +94,11 @@ export function setupCsrfInterceptor(axiosInstance: AxiosLikeInstance) {
     const csrfCookie = cookies.find(c => c.trim().startsWith('csrf-token='));
     
     if (csrfCookie) {
-      const token = csrfCookie.split('=')[1];
-      config.headers['x-csrf-token'] = token;
+      const tokenParts = csrfCookie.split('=');
+      const token = tokenParts[1]?.trim();
+      if (token && token.length > 0) {
+        config.headers['x-csrf-token'] = token;
+      }
     }
 
     return config;

--- a/frontend/lib/enhanced-csrf.ts
+++ b/frontend/lib/enhanced-csrf.ts
@@ -43,7 +43,9 @@ export const ENHANCED_CSRF_CONFIG = {
 
 // Allowed origins for CSRF validation
 const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS 
-  ? process.env.ALLOWED_ORIGINS.split(',').map(o => o.trim())
+  ? process.env.ALLOWED_ORIGINS.split(',')
+      .map(o => o.trim())
+      .filter(o => o.length > 0)
   : [
       'http://localhost:3000',
       'http://localhost:3001',

--- a/frontend/pages/api/watchlist.ts
+++ b/frontend/pages/api/watchlist.ts
@@ -21,7 +21,14 @@ export default async function handler(
       .json({ error: 'Unauthorized: No token provided' });
   }
 
-  const idToken = authHeader.split('Bearer ')[1];
+  const tokenParts = authHeader.split('Bearer ');
+  const idToken = tokenParts[1];
+  
+  if (!idToken || idToken.trim().length === 0) {
+    return res
+      .status(401)
+      .json({ error: 'Unauthorized: Invalid token format' });
+  }
 
   let decodedToken;
   try {


### PR DESCRIPTION
Add comprehensive null safety checks for string split operations in critical API endpoints and utilities. Fixed unsafe array access in Authorization header parsing (watchlist.ts), CSRF cookie value extraction (useCsrfToken.ts), and ALLOWED_ORIGINS configuration (enhanced-csrf.ts) that could cause undefined access and runtime crashes. All split results are now validated before accessing array indices.

closes: #594

@GauravKarakoti  plz review it 