### PR TITLE
fix: enhance deposit address validation in SwapConfirmation

### DIFF
--- a/frontend/components/SwapConfirmation.tsx
+++ b/frontend/components/SwapConfirmation.tsx
@@ -311,7 +311,7 @@ export default function SwapConfirmation({ quote, confidence: _confidence, onAmo
   }
 
   const handleConfirm = async () => {
-    if (!quote) {
+    if (!quote || !quote.depositAddress) {
       alert('Error: Deposit address is missing. Cannot proceed.')
       return
     }
@@ -327,18 +327,41 @@ export default function SwapConfirmation({ quote, confidence: _confidence, onAmo
       return
     }
 
-    console.log('Processing swap to SideShift address:', quote.depositAddress)
+    // CRITICAL: Validate deposit address before proceeding
+    const depositAddress = quote.depositAddress.trim()
+    
+    if (!depositAddress || depositAddress.length === 0) {
+      console.error('SECURITY: Empty deposit address detected')
+      alert('ERROR: Invalid deposit address. Cannot proceed.')
+      return
+    }
 
-    const addressCheck = validateDepositAddressForNetwork(quote.depositNetwork, quote.depositAddress)
+    console.log('Processing swap to SideShift address:', depositAddress)
+
+    const addressCheck = validateDepositAddressForNetwork(quote.depositNetwork, depositAddress)
     if (!addressCheck.passed) {
-      console.error('SECURITY: Rejected invalid deposit address from quote:', { quoteId: quote.id, depositNetwork: quote.depositNetwork, depositAddress: quote.depositAddress })
+      console.error('SECURITY: Rejected invalid deposit address from quote:', { 
+        quoteId: quote.id, 
+        depositNetwork: quote.depositNetwork, 
+        depositAddress: depositAddress 
+      })
       alert(`Error: ${addressCheck.message}. Cannot proceed with swap.`)
       return
     }
 
-    if (quote.depositAddress.toLowerCase() === address?.toLowerCase()) {
-      console.error('SECURITY: Attempted to send funds to user\'s own address instead of SideShift!')
+    // CRITICAL: Prevent sending to user's own wallet
+    if (depositAddress.toLowerCase() === address?.toLowerCase()) {
+      console.error('SECURITY: Attempted to send funds to user\'s own address instead of SideShift!', {
+        userAddress: address,
+        depositAddress: depositAddress
+      })
       alert('ERROR: Cannot send funds to your own wallet. Must send to SideShift deposit address.')
+      return
+    }
+
+    // CRITICAL: Verify deposit address is different from connected wallet
+    if (!address) {
+      alert('ERROR: Wallet not connected.')
       return
     }
 
@@ -364,23 +387,51 @@ export default function SwapConfirmation({ quote, confidence: _confidence, onAmo
         }
         const amount = parseUnits(quote.depositAmount, decimals)
 
+        // CRITICAL: ERC20 transfer - ensure we're sending to SideShift deposit address
+        console.log('Preparing ERC20 transfer:', {
+          token: networkInfo.tokenContract,
+          to: depositAddress,
+          amount: quote.depositAmount,
+          userWallet: address
+        })
+
         transactionDetails = {
           to: networkInfo.tokenContract as `0x${string}`,
           value: BigInt(0),
           data: encodeFunctionData({
             abi: erc20Abi,
             functionName: 'transfer',
-            args: [quote.depositAddress as `0x${string}`, amount],
+            args: [depositAddress as `0x${string}`, amount],
           }),
           chainId: depositChainId,
         }
       } else {
+        // CRITICAL: Native token transfer - ensure we're sending to SideShift deposit address
+        console.log('Preparing native token transfer:', {
+          to: depositAddress,
+          value: quote.depositAmount,
+          userWallet: address
+        })
+
         transactionDetails = {
-          to: quote.depositAddress as `0x${string}`,
+          to: depositAddress as `0x${string}`,
           value: parseUnits(quote.depositAmount, 18),
           chainId: depositChainId,
         }
       }
+
+      // Final validation before sending
+      if (transactionDetails.to.toLowerCase() === address.toLowerCase()) {
+        console.error('CRITICAL: Transaction target is user wallet, aborting!', transactionDetails)
+        alert('CRITICAL ERROR: Transaction would send to your own wallet. Aborting for safety.')
+        return
+      }
+
+      console.log('Final transaction details:', {
+        ...transactionDetails,
+        depositAddress: depositAddress,
+        userAddress: address
+      })
 
       if (connectedChain?.id !== depositChainId) {
         if (!switchChainAsync) {


### PR DESCRIPTION

**Title:** Fix swap destination address validation and prevent self-transfers

**Description:**
Enhanced deposit address validation in SwapConfirmation to ensure transactions always go to SideShift deposit address, not user's wallet.

**Related Issue:**
Closes #604

**Type of Change:**
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

**Changes Made:**
- Added explicit validation for empty/missing deposit addresses
- Enhanced security check preventing self-transfers with detailed logging
- Added transaction logging for both ERC20 and native transfers showing deposit vs user address
- Added final validation checkpoint before transaction execution
- Improved error messages for better debugging

**Testing Done:**
- [x] Tested locally (npm run dev)
- [x] No TypeScript errors
- [x] Code follows project style

**Additional Notes:**
The code already had correct logic to use `quote.depositAddress`, but now includes multiple validation layers and comprehensive logging to prevent any edge cases where funds could be sent to the wrong address.