### PR TITLE
refactor: Move hardcoded configuration constants to environment variables

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -17,3 +17,24 @@ ERROR_EMAIL=
 REPUTATION_CONTRACT_ADDRESS=
 REPUTATION_OWNER_PRIVATE_KEY=
 SEPOLIA_RPC_URL=
+
+# === Worker & Scheduler Configuration ===
+# Price Alert Worker - how often to check for price alerts (milliseconds)
+PRICE_ALERT_CHECK_INTERVAL_MS=60000
+
+# Order Monitor - how often the tick loop runs (milliseconds)
+ORDER_MONITOR_TICK_INTERVAL_MS=10000
+
+# DCA Scheduler - how often to process DCA schedules (milliseconds)
+DCA_SCHEDULER_CHECK_INTERVAL_MS=60000
+
+# === Order Processing Configuration ===
+# Maximum concurrent SideShift API calls
+MAX_CONCURRENT_ORDERS=5
+
+# === DCA Scheduler Configuration ===
+# Delay before retrying failed DCA executions (minutes)
+DCA_RETRY_DELAY_MINUTES=5
+
+# Maximum time allocated for processing a DCA schedule (minutes)
+DCA_MAX_PROCESSING_TIME_MINUTES=10

--- a/bot/src/constants.ts
+++ b/bot/src/constants.ts
@@ -3,3 +3,24 @@
  * Centralising here prevents the two modules from drifting out of sync.
  */
 export const TERMINAL_STATUSES_LIST: string[] = ['settled', 'expired', 'refunded', 'failed'];
+
+/**
+ * Configuration documentation for environment variables
+ * 
+ * WORKER & SCHEDULER INTERVALS (milliseconds):
+ * - PRICE_ALERT_CHECK_INTERVAL_MS: How often price alerts are checked (default: 60000ms = 60 seconds)
+ * - ORDER_MONITOR_TICK_INTERVAL_MS: Order monitoring loop interval (default: 10000ms = 10 seconds)
+ * - DCA_SCHEDULER_CHECK_INTERVAL_MS: DCA schedule processing interval (default: 60000ms = 60 seconds)
+ * 
+ * ORDER PROCESSING LIMITS:
+ * - MAX_CONCURRENT_ORDERS: Maximum concurrent SideShift API calls (default: 5)
+ * 
+ * DCA TIMING (minutes):
+ * - DCA_RETRY_DELAY_MINUTES: Wait time before retrying failed DCA executions (default: 5 minutes)
+ * - DCA_MAX_PROCESSING_TIME_MINUTES: Maximum time allocated for processing a schedule (default: 10 minutes)
+ * 
+ * SIDESHIFT CONFIGURATION:
+ * - SIDESHIFT_API_KEY: SideShift API key for server-side operations (REQUIRED)
+ * - SIDESHIFT_AFFILIATE_ID: Optional affiliate ID (fallback to AFFILIATE_ID)
+ * - SIDESHIFT_CLIENT_IP: Client IP for SideShift requests
+ */

--- a/bot/src/services/dca-scheduler.ts
+++ b/bot/src/services/dca-scheduler.ts
@@ -3,8 +3,9 @@ import { db, dcaSchedules, orders, watchedOrders, getUser } from './database';
 import { createQuote, createOrder } from './sideshift-client';
 import logger from './logger';
 
-const RETRY_DELAY_MINUTES = 5;
-const MAX_PROCESSING_TIME_MINUTES = 10;
+const RETRY_DELAY_MINUTES = parseInt(process.env.DCA_RETRY_DELAY_MINUTES ?? '5', 10);
+const MAX_PROCESSING_TIME_MINUTES = parseInt(process.env.DCA_MAX_PROCESSING_TIME_MINUTES ?? '10', 10);
+const SCHEDULER_CHECK_INTERVAL_MS = parseInt(process.env.DCA_SCHEDULER_CHECK_INTERVAL_MS ?? '60000', 10);
 
 export class DCAScheduler {
   private intervalId: NodeJS.Timeout | null = null;
@@ -13,7 +14,7 @@ export class DCAScheduler {
   start() {
     if (this.isRunning) return;
     this.isRunning = true;
-    this.intervalId = setInterval(() => this.processSchedules(), 60 * 1000);
+    this.intervalId = setInterval(() => this.processSchedules(), SCHEDULER_CHECK_INTERVAL_MS);
     logger.info('DCA Scheduler started');
   }
 

--- a/bot/src/services/order-monitor.ts
+++ b/bot/src/services/order-monitor.ts
@@ -49,10 +49,10 @@ export interface OrderMonitorDeps {
 export const TERMINAL_STATUSES = new Set(TERMINAL_STATUSES_LIST);
 
 /** Maximum concurrent API calls to SideShift */
-const MAX_CONCURRENT = 5;
+const MAX_CONCURRENT = parseInt(process.env.MAX_CONCURRENT_ORDERS ?? '5', 10);
 
 /** How often the tick loop runs (ms) */
-const TICK_INTERVAL = 10_000; // 10 seconds
+const TICK_INTERVAL = parseInt(process.env.ORDER_MONITOR_TICK_INTERVAL_MS ?? '10000', 10);
 
 // --- Backoff Logic ---
 

--- a/bot/src/services/sideshift-client.ts
+++ b/bot/src/services/sideshift-client.ts
@@ -4,7 +4,7 @@ import dotenv from 'dotenv';
 import { SIDESHIFT_CONFIG } from '../../../shared/config/sideshift';
 dotenv.config();
 const AFFILIATE_ID = process.env.SIDESHIFT_AFFILIATE_ID || process.env.AFFILIATE_ID || '';
-const API_KEY = process.env.SIDESHIFT_API_KEY || process.env.SIDESHIFT_API_KEY;
+const API_KEY = process.env.SIDESHIFT_API_KEY || '';
 const DEFAULT_USER_IP = process.env.SIDESHIFT_CLIENT_IP;
 
 export interface SideShiftPair {

--- a/bot/src/workers/price-alerts.ts
+++ b/bot/src/workers/price-alerts.ts
@@ -6,7 +6,7 @@ import { priceAlerts } from '../../../shared/schema';
 import logger from '../services/logger';
 import { batchLoadUsersByIds } from '../utils/dataLoader';
 
-const CHECK_INTERVAL_MS = 60 * 1000; // 60 seconds
+const CHECK_INTERVAL_MS = parseInt(process.env.PRICE_ALERT_CHECK_INTERVAL_MS ?? '60000', 10);
 
 // Asset ID mapping for CoinGecko
 const ASSET_ID_MAP: Record<string, string> = {


### PR DESCRIPTION
Move critical hardcoded configuration values to environment variables while maintaining backward compatibility with safe defaults.

-  Refactored order-monitor.ts (MAX_CONCURRENT, TICK_INTERVAL), 
- price-alerts.ts (CHECK_INTERVAL_MS),
-  dca-scheduler.ts (RETRY_DELAY_MINUTES,MAX_PROCESSING_TIME_MINUTES, SCHEDULER_CHECK_INTERVAL_MS),
-  and sideshift-client.ts (API key fallback).

 All constants now read from environment variables with defaults, enabling runtime configuration changes without code modifications. Updated .env.example with all new variables and documented configuration in constants.ts.

closes: #596

@GauravKarakoti  plz review it

