### PR TITLE
refactor: centralize SideShift config and add helper functions

### DIFF
--- a/bot/src/services/bridge-client.ts
+++ b/bot/src/services/bridge-client.ts
@@ -8,7 +8,7 @@
 
 import axios from 'axios';
 import dotenv from 'dotenv';
-import { SIDESHIFT_CONFIG } from '../../../shared/config/sideshift';
+import { SIDESHIFT_CONFIG, getApiUrl } from '../../../shared/config/sideshift';
 
 dotenv.config();
 
@@ -42,7 +42,7 @@ interface BridgeConfig {
 const BRIDGE_CONFIGS: Record<string, BridgeConfig> = {
   sideshift: {
     name: 'sideshift',
-    displayName: 'SideShift.ai',
+    displayName: SIDESHIFT_CONFIG.DISPLAY_NAME,
     supportedChains: ['ethereum', 'polygon', 'arbitrum', 'optimism', 'avalanche', 'bsc', 'base', 'solana'],
     features: { instantExecution: false },
     reliability: { score: 85 },
@@ -195,7 +195,7 @@ async function getSideShiftQuotes(request: BridgeQuoteRequest): Promise<Aggregat
     }
 
     const response = await axios.post(
-      `${SIDESHIFT_BASE_URL}/quotes`,
+      getApiUrl('quotes'),
       {
         depositCoin: request.fromToken,
         depositNetwork: request.fromChain,
@@ -210,7 +210,7 @@ async function getSideShiftQuotes(request: BridgeQuoteRequest): Promise<Aggregat
     const data = response.data;
     const quote: BridgeQuote = {
       bridge: 'sideshift',
-      displayName: 'SideShift.ai',
+      displayName: SIDESHIFT_CONFIG.DISPLAY_NAME,
       fromChain: request.fromChain,
       toChain: request.toChain,
       fromToken: request.fromToken,

--- a/frontend/app/api/sideshift/checkout/route.ts
+++ b/frontend/app/api/sideshift/checkout/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import axios from 'axios';
-import { SIDESHIFT_CONFIG } from '../../../../../shared/config/sideshift';
+import { SIDESHIFT_CONFIG, getApiUrl, getCheckoutUrl } from '../../../../../shared/config/sideshift';
 
 const API_KEY = process.env.SIDESHIFT_API_KEY; // Server-side only, no NEXT_PUBLIC_
 const AFFILIATE_ID = process.env.AFFILIATE_ID;
@@ -30,7 +30,7 @@ export async function POST(req: NextRequest) {
 
     // Make request to SideShift API with server-side API key
     const response = await axios.post(
-      `${SIDESHIFT_CONFIG.BASE_URL}/checkout`,
+      getApiUrl('checkout'),
       {
         settleCoin,
         settleNetwork,
@@ -51,7 +51,7 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({
       id: response.data.id,
-      url: `${SIDESHIFT_CONFIG.CHECKOUT_URL}/${response.data.id}`,
+      url: getCheckoutUrl(response.data.id),
       settleAmount: response.data.settleAmount,
       settleCoin: response.data.settleCoin,
     });

--- a/frontend/app/api/sideshift/quote/route.ts
+++ b/frontend/app/api/sideshift/quote/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import axios from 'axios';
-import { SIDESHIFT_CONFIG } from '../../../../../shared/config/sideshift';
+import { SIDESHIFT_CONFIG, getApiUrl } from '../../../../../shared/config/sideshift';
 
 const API_KEY = process.env.SIDESHIFT_API_KEY; // Server-side only, no NEXT_PUBLIC_
 const AFFILIATE_ID = process.env.AFFILIATE_ID;
@@ -30,7 +30,7 @@ export async function POST(req: NextRequest) {
 
     // Make request to SideShift API with server-side API key
     const response = await axios.post(
-      `${SIDESHIFT_CONFIG.BASE_URL}/quotes`,
+      getApiUrl('quotes'),
       {
         depositCoin,
         depositNetwork,

--- a/frontend/components/SwapConfirmation.tsx
+++ b/frontend/components/SwapConfirmation.tsx
@@ -18,6 +18,7 @@ import { parseEther, formatEther, type Chain, erc20Abi, formatUnits, parseUnits,
 import { mainnet, polygon, arbitrum, avalanche, optimism, bsc, base } from 'wagmi/chains'
 import { validateDepositAddressForNetwork } from '@/utils/addressValidation'
 import { getCoins, type Coin, type CoinNetwork } from '@/utils/sideshift-client'
+import { SIDESHIFT_CONFIG } from '../../shared/config/sideshift'
 
 export interface QuoteData {
   depositAmount: string
@@ -456,7 +457,7 @@ export default function SwapConfirmation({ quote, confidence: _confidence, onAmo
           <Zap className="w-4 h-4 text-yellow-500 shrink-0" /> Confirm Swap
         </h4>
         <div className="text-xs bg-gray-100 px-2 py-1 rounded-full text-gray-500">
-          SideShift.ai API
+          {SIDESHIFT_CONFIG.DISPLAY_NAME} API
         </div>
       </div>
 

--- a/frontend/utils/sideshift-client.ts
+++ b/frontend/utils/sideshift-client.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { SIDESHIFT_CONFIG } from '../../shared/config/sideshift';
+import { SIDESHIFT_CONFIG, getApiUrl } from '../../shared/config/sideshift';
 import { validateDepositAddressForNetwork } from './addressValidation';
 
 // API key is now server-side only - client calls backend API routes
@@ -135,7 +135,7 @@ export async function getCoins(): Promise<Coin[]> {
   }
 
   try {
-    const response = await axios.get(`${SIDESHIFT_CONFIG.BASE_URL}/coins`);
+    const response = await axios.get(getApiUrl('coins'));
     coinsCache = response.data;
     coinsCacheTimestamp = Date.now();
     return response.data;
@@ -240,7 +240,7 @@ export async function getCoinPrices(): Promise<CoinPrice[]> {
           }
 
           const quoteResponse = await axios.post(
-            `${SIDESHIFT_CONFIG.BASE_URL}/quotes`,
+            getApiUrl('quotes'),
             {
               depositCoin: coin.coin,
               depositNetwork: network.network,
@@ -286,7 +286,7 @@ export async function getCoinPrices(): Promise<CoinPrice[]> {
 export async function getCoinPrice(coin: string, network: string): Promise<string | null> {
   try {
     const quoteResponse = await axios.post(
-      `${SIDESHIFT_CONFIG.BASE_URL}/quotes`,
+      getApiUrl('quotes'),
       {
         depositCoin: coin,
         depositNetwork: network,

--- a/shared/config/sideshift.ts
+++ b/shared/config/sideshift.ts
@@ -7,4 +7,32 @@ export const SIDESHIFT_CONFIG = {
   CHECKOUT_URL: 'https://pay.sideshift.ai/checkout',
   HELP_URL: 'https://help.sideshift.ai/en/',
   FAQ_URL: 'https://docs.sideshift.ai/faq/',
-};
+  DISPLAY_NAME: 'SideShift.ai',
+} as const;
+
+/**
+ * Generate a tracking URL for a specific transaction
+ * @param transactionId - The SideShift transaction ID
+ * @returns Full tracking URL
+ */
+export function getTrackingUrl(transactionId: string): string {
+  return `${SIDESHIFT_CONFIG.TRACKING_URL}/${transactionId}`;
+}
+
+/**
+ * Generate a checkout URL for a specific checkout session
+ * @param checkoutId - The SideShift checkout ID
+ * @returns Full checkout URL
+ */
+export function getCheckoutUrl(checkoutId: string): string {
+  return `${SIDESHIFT_CONFIG.CHECKOUT_URL}/${checkoutId}`;
+}
+
+/**
+ * Get API endpoint URL
+ * @param endpoint - The API endpoint path (e.g., 'quotes', 'checkout')
+ * @returns Full API URL
+ */
+export function getApiUrl(endpoint: string): string {
+  return `${SIDESHIFT_CONFIG.BASE_URL}/${endpoint}`;
+}


### PR DESCRIPTION

**Title:** Centralize hardcoded SideShift URLs and add helper functions

**Description:**
Refactored all hardcoded SideShift URLs to use centralized config with type-safe helper functions for better maintainability.

**Related Issue:**
Closes #629

**Type of Change:**
- [x] ♻️ Code refactoring

**Changes Made:**
- Enhanced `shared/config/sideshift.ts` with DISPLAY_NAME constant and helper functions (getApiUrl, getTrackingUrl, getCheckoutUrl)
- Updated 6 files to use centralized config instead of hardcoded URLs
- Made config immutable with `as const` for type safety
- Replaced all string concatenation with helper functions

**Testing Done:**
- [x] No TypeScript errors
- [x] Code follows project style
- [x] All imports resolved correctly

@GauravKarakoti kindly review the code and assign label 
What i have done is -
- Identifying all hardcoded URLs across multiple files (frontend, bot, shared)
- Creating type-safe helper functions
- Updating 6 different files with correct relative import paths
- Ensuring backward compatibility while improving code structure

The refactor improves maintainability by centralizing all SideShift configuration in one place, making future endpoint updates trivial.