### PR TITLE
feat: implement on-chain agent reputation tracking and display

### DIFF
--- a/bot/src/bot.ts
+++ b/bot/src/bot.ts
@@ -13,6 +13,7 @@ import * as db from './services/database';
 import { OrderMonitor } from './services/order-monitor';
 import { parseUserCommand } from './services/parseUserCommand';
 import { reputationService } from './services/reputation-service';
+import { TERMINAL_STATUSES_LIST } from './constants';
 import { limitOrderWorker } from './workers/limitOrderWorker';
 import { DCAScheduler } from './services/dca-scheduler';
 
@@ -46,8 +47,12 @@ const orderMonitor = new OrderMonitor({
 
       // --- AGENT REPUTATION LOGIC ---
       // When a swap completes, record it on-chain
+      // Ensure we only record once by checking if the previous status was not already terminal
+      const wasTerminal = TERMINAL_STATUSES_LIST.includes(oldStatus);
+      const isTerminal = TERMINAL_STATUSES_LIST.includes(newStatus);
       const botAddress = reputationService.getBotAddress();
-      if (botAddress) {
+
+      if (botAddress && isTerminal && !wasTerminal) {
         if (newStatus === 'settled') {
           await reputationService.recordSwapOutcome(botAddress, true);
         } else if (['expired', 'refunded', 'failed'].includes(newStatus)) {

--- a/bot/src/services/reputation-service.ts
+++ b/bot/src/services/reputation-service.ts
@@ -96,15 +96,24 @@ class ReputationService {
         try {
             // contract.getReputation returns [totalSwaps, successSwaps] as BigInts
             const result = await this.contract.getReputation(agent);
-            const total = Number(result[0]);
-            const success = Number(result[1]);
+            
+            // Result is usually an array/object with BigInt properties
+            const total = BigInt(result[0]); // Ensure BigInt
+            const success = BigInt(result[1]); // Ensure BigInt
 
             let score = "0.0";
-            if (total > 0) {
-                score = ((success / total) * 100).toFixed(1);
+            if (total > 0n) {
+                // Calculation: (success * 1000n) / total (yields e.g. 985 for 98.5%)
+                const basisPoints = (success * 1000n) / total;
+                const numericScore = Number(basisPoints) / 10;
+                score = numericScore.toFixed(1);
             }
 
-            return { total, success, score };
+            return { 
+                total: Number(total), 
+                success: Number(success), 
+                score 
+            };
         } catch (error) {
             logger.error(`[ReputationService] Failed to fetch reputation for ${agent}:`, error instanceof Error ? error : new Error(String(error)));
             return null;

--- a/bot/src/workers/limitOrderWorker.ts
+++ b/bot/src/workers/limitOrderWorker.ts
@@ -267,7 +267,7 @@ export class LimitOrderWorker {
         logger.error('Failed to update DB & watch order; attempting to revert limit order status', err);
         try {
           // Revert to a safe, pre-executed status so the order can be retried/handled
-          await updateLimitOrderStatus(order.id, 'pending', null as any);
+          await updateLimitOrderStatus(order.id, 'pending', undefined);
         } catch (revertErr) {
           logger.error('Failed to revert limit order status after watch-order failure', revertErr);
         }


### PR DESCRIPTION
# Implement On-Chain Agent Reputation System

## Description
This PR introduces an On-Chain Reputation System for the SwapSmith bot. It calculates and displays a "Trust Score" for the bot based on the ratio of successful to total swaps executed. The system leverages the `AgentReputation` smart contract to record swap outcomes and retrieve aggregated statistics.

## Changes
- **`bot/src/services/reputation-service.ts`**:
  - Implemented `getReputation(agent)` to fetch total and successful swap counts from the blockchain.
  - Implemented `getBotAddress()` to retrieve the bot's configuring wallet address.
  - Calculated the Trust Score percentage.
- **`bot/src/bot.ts`**:
  - Integrated `reputationService` into the `OrderMonitor` callback.
  - Added logic to automatically call `recordSwapOutcome(botAddress, true/false)` when orders settle or fail.
  - Added a new `/reputation` command for users to query the bot's current Trust Score.
- **`bot/src/workers/limitOrderWorker.ts`**:
  - Updated `executeOrder` to register new limit orders with `OrderMonitor` (via `addWatchedOrder`), ensuring they are tracked for reputation updates upon settlement.

## Related Issue
Fixes #619 - Implement On-Chain Agent Reputation

## How to Test
1. **Configure Environment**: Ensure `REPUTATION_CONTRACT_ADDRESS` and private key environment variables are set.
2. **Check Reputation**: Run the bot and send `/reputation`.
   - Expect a response like:
     > **Agent Reputation**
     > Trust Score: **98.5%**
     > Success Rate: 197/200 swaps
3. **Verify Updates**: Perform a "Swap and Stake" or simulate an order completion.
   - Verify that `recordSwapOutcome` is called (check logs).
   - Verify the on-chain stats update using `/reputation` again.