### PR TITLE
Fix bot container startup by properly parsing DATABASE_URL in wait script

### DIFF
--- a/bot/scripts/wait-for-db-and-migrate.sh
+++ b/bot/scripts/wait-for-db-and-migrate.sh
@@ -7,9 +7,46 @@ SLEEP_SECONDS="${SLEEP_SECONDS:-2}"
 if [ -z "$DATABASE_URL" ]; then
   echo "DATABASE_URL is not set; cannot wait for database"
 else
-  echo "Waiting for database at $DATABASE_URL..."
+  echo "Waiting for database..."
+  
+  # Parse PostgreSQL connection string
+  # Format: postgres://user:password@host:port/dbname
+  DB_URL="$DATABASE_URL"
+  
+  # Remove postgres:// prefix
+  DB_URL="${DB_URL#postgres://}"
+  DB_URL="${DB_URL#postgresql://}"
+  
+  # Extract user and password
+  if echo "$DB_URL" | grep -q "@"; then
+    USERPASS="${DB_URL%@*}"
+    DB_URL="${DB_URL#*@}"
+    DB_USER="${USERPASS%:*}"
+    DB_PASS="${USERPASS#*:}"
+  else
+    DB_USER="postgres"
+    DB_PASS=""
+  fi
+  
+  # Extract host and port
+  if echo "$DB_URL" | grep -q ":"; then
+    DB_HOST="${DB_URL%:*}"
+    REST="${DB_URL#*:}"
+    DB_PORT="${REST%/*}"
+    DB_NAME="${REST#*/}"
+  else
+    DB_HOST="${DB_URL%/*}"
+    DB_PORT="5432"
+    DB_NAME="${DB_URL#*/}"
+  fi
+  
+  # Provide defaults
+  DB_HOST="${DB_HOST:-localhost}"
+  DB_PORT="${DB_PORT:-5432}"
+  DB_NAME="${DB_NAME:-postgres}"
+  
   COUNTER=0
-  until pg_isready -d "$DATABASE_URL"; do
+  until pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER"; do
     COUNTER=$((COUNTER + 1))
     if [ "$COUNTER" -ge "$MAX_RETRIES" ]; then
       echo "Database not ready after $MAX_RETRIES attempts, exiting"


### PR DESCRIPTION
### Description:
The bot container was failing to start because the [wait-for-db-and-migrate.sh](vscode-file://vscode-app/c:/Users/omkar/AppData/Local/Programs/Microsoft%20VS%20Code/61b3d0ab13/resources/app/out/vs/code/electron-browser/workbench/workbench.html) script passed the raw PostgreSQL URI to pg_isready, which doesn't parse connection strings. This fix parses the DATABASE_URL environment variable to extract the host, port, user, and database name, then passes these as individual parameters to pg_isready. This ensures the database readiness check works correctly before attempting migrations, resolving the race condition that caused startup failures.

### Key Changes:

- Parse PostgreSQL connection URL format (postgres://user:password@host:port/dbname)
- Extract individual components: host, port, user, database name
- Pass parsed parameters to pg_isready with -h, -p, and -U flags
- Provides sensible defaults (localhost, 5432, postgres) when components are missing

closes: #606
@GauravKarakoti  plz review it

