### PR TITLE
fix(#625): use dynamic confidence scores for trust indicators

### DIFF
--- a/frontend/app/terminal/page.tsx
+++ b/frontend/app/terminal/page.tsx
@@ -465,7 +465,7 @@ export default function TerminalPage() {
             toAsset: item.toAsset,
             toChain: item.toChain,
             portfolio: undefined,
-            confidence: 100,
+            confidence: command.confidence,
           };
           await executeSwap(subCommand);
         }
@@ -695,7 +695,7 @@ export default function TerminalPage() {
                                 amount: parseFloat(newAmount),
                                 fromChain: quoteData.depositNetwork,
                                 toChain: quoteData.settleNetwork,
-                                confidence: 100,
+                                confidence: (msg.data as { confidence: number }).confidence,
                                 requiresConfirmation: false,
                                 settleAsset: quoteData.settleCoin,
                                 settleNetwork: quoteData.settleNetwork,

--- a/frontend/components/ChatInterface.tsx
+++ b/frontend/components/ChatInterface.tsx
@@ -670,7 +670,7 @@ export default function ChatInterface() {
   const handleIntentConfirm = async (confirmed: boolean) => {
     if (confirmed && pendingCommand) {
       if (pendingCommand.intent === 'portfolio') {
-        const confirmedCmd = { ...pendingCommand, requiresConfirmation: false, confidence: 100 };
+        const confirmedCmd = { ...pendingCommand, requiresConfirmation: false, confidence: pendingCommand.confidence };
 
         if (confirmedCmd.portfolio) {
           const items: PortfolioItem[] = confirmedCmd.portfolio.map((item, index) => ({
@@ -859,7 +859,7 @@ export default function ChatInterface() {
                                 amount: parseFloat(newAmount),
                                 fromChain: quoteData.depositNetwork,
                                 toChain: quoteData.settleNetwork,
-                                confidence: 100,
+                                confidence: msg.data?.confidence ?? 100,
                                 requiresConfirmation: false,
                                 settleAsset: quoteData.settleCoin,
                                 settleNetwork: quoteData.settleNetwork,

--- a/frontend/utils/terminal-utils.ts
+++ b/frontend/utils/terminal-utils.ts
@@ -10,17 +10,17 @@ export interface Message {
   content: string;
   timestamp: Date;
   type?:
-    | 'message'
-    | 'intent_confirmation'
-    | 'swap_confirmation'
-    | 'yield_info'
-    | 'checkout_link';
+  | 'message'
+  | 'intent_confirmation'
+  | 'swap_confirmation'
+  | 'yield_info'
+  | 'checkout_link';
   data?:
-    | ParsedCommand
-    | { quoteData: Record<string, unknown>; confidence: number }
-    | { url: string }
-    | { parsedCommand: ParsedCommand }
-    | Record<string, unknown>;
+  | ParsedCommand
+  | { quoteData: Record<string, unknown>; confidence: number }
+  | { url: string }
+  | { parsedCommand: ParsedCommand }
+  | Record<string, unknown>;
 }
 
 /**
@@ -122,7 +122,7 @@ export function buildPortfolioCommands(command: ParsedCommand): ParsedCommand[] 
     toAsset: item.toAsset,
     toChain: item.toChain,
     portfolio: undefined,
-    confidence: 100,
+    confidence: command.confidence,
   }));
 }
 


### PR DESCRIPTION
## Description
Fixes #625. Replaced hardcoded `confidence: 100` values with dynamic AI parse confidence scores in the frontend Terminal and Chat interfaces. 

## Changes Made
- **ChatInterface.tsx**: Passed original AI confidence scores instead of hardcoded `100` during intent confirmations and amount changes.
- **page.tsx**: Removed hardcoded confidence during portfolio action splitting and swap confirmation handlers.
- **terminal-utils.ts**: Modified [buildPortfolioCommands](cci:1://file:///d:/Open-Source-Projects/SwapSmith/frontend/utils/terminal-utils.ts:106:0-126:1) to retain the original parsed command's confidence.

## Verification
- [x] Trust Indicators now accurately reflect the AI parses (e.g., 75%, 80%) instead of a static 100%.
- [x] Tested web frontend components for regressions.
- [x] Verified `tsc` type check passes.
